### PR TITLE
Add optional Exodus II mesh and field read/write support

### DIFF
--- a/.github/workflows/macos-exodus.yml
+++ b/.github/workflows/macos-exodus.yml
@@ -1,0 +1,129 @@
+name: macOS Build (Exodus)
+
+# Builds GetFEM on macOS with the Exodus II reader/writer enabled and runs the
+# Exodus round-trip tests. A second job builds with the feature disabled to
+# check that --enable-exodus is opt-in: a default build neither requires nor
+# links NetCDF and leaves all Exodus code compiled out.
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  exodus:
+    name: build with --enable-exodus and run Exodus tests
+    runs-on: macos-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v5
+
+    - name: Install dependencies from Homebrew
+      # gcc provides gcc/g++/gfortran from one release; openblas, superlu, qhull
+      # and netcdf are keg-only so their prefixes are passed to configure.
+      run: |
+        brew update
+        brew install gcc openblas superlu qhull netcdf autoconf automake libtool
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+
+    - name: Install numpy and scipy
+      run: |
+        python -m pip install --upgrade pip
+        pip install numpy scipy
+        python -c "import numpy, scipy; print('NumPy', numpy.__version__, 'SciPy', scipy.__version__)"
+
+    - name: Generate configure script
+      run: bash autogen.sh
+
+    - name: Configure (SuperLU + Exodus + Python)
+      run: |
+        GCCVER="$(brew list --versions gcc | head -1 | awk '{print $2}' | cut -d. -f1)"
+        GF="$(brew --prefix)/bin"
+        GF_LIBDIR="$(dirname "$("$GF/gfortran-$GCCVER" -print-file-name=libgfortran.dylib)")"
+        NC="$(brew --prefix netcdf)"
+        mkdir build && cd build
+        ../configure \
+          --prefix="$PWD/../install" \
+          CC="$GF/gcc-$GCCVER" CXX="$GF/g++-$GCCVER" FC="$GF/gfortran-$GCCVER" \
+          BLAS_LIBS="-L$(brew --prefix openblas)/lib -lopenblas" \
+          CPPFLAGS="-I$(brew --prefix superlu)/include -I$(brew --prefix qhull)/include -I$(brew --prefix openblas)/include -I$NC/include" \
+          LDFLAGS="-L$(brew --prefix superlu)/lib -L$(brew --prefix qhull)/lib -L$(brew --prefix openblas)/lib -L$NC/lib -Wl,-rpath,$NC/lib -L$GF_LIBDIR" \
+          --enable-superlu --enable-qhull --enable-force-singlethread-blas \
+          --enable-exodus --with-netcdf-include-dir="$NC/include" \
+          --enable-python PYTHON="$(which python)"
+        echo "--- config: Exodus macro ---"
+        grep GETFEM_HAVE_EXODUS src/getfem/getfem_arch_config.h
+
+    - name: Build
+      # Work around GetFEM's out-of-tree cubature quirk: seed the generated
+      # getfem_im_list.h into the source tree, then (re)build.
+      run: |
+        NJ="$(sysctl -n hw.ncpu)"
+        make -C build -j"$NJ" || true
+        if [ -f build/cubature/getfem_im_list.h ]; then
+          cp build/cubature/getfem_im_list.h cubature/getfem_im_list.h
+          cp build/cubature/getfem_im_list.h src/getfem/getfem_im_list.h
+        fi
+        make -C build -j"$NJ"
+
+    - name: Run Exodus tests (C++ and Python)
+      run: |
+        make -C build/tests check TESTS=test_exodus.pl
+        make -C build/interface/tests/python check TESTS=check_exodus.py
+
+    - name: Show test logs on failure
+      if: failure()
+      run: |
+        cat build/tests/test_exodus.log 2>/dev/null || true
+        cat build/interface/tests/python/check_exodus.log 2>/dev/null || true
+
+  no-exodus:
+    name: default build is inert (no NetCDF, feature off)
+    runs-on: macos-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v5
+
+    - name: Install dependencies (deliberately NO netcdf)
+      run: |
+        brew update
+        brew install gcc openblas superlu qhull autoconf automake libtool
+
+    - name: Generate configure script
+      run: bash autogen.sh
+
+    - name: Configure WITHOUT --enable-exodus
+      # With NetCDF absent and the flag not given, configure must still succeed:
+      # the Exodus block must not probe NetCDF at all.
+      run: |
+        GCCVER="$(brew list --versions gcc | head -1 | awk '{print $2}' | cut -d. -f1)"
+        GF="$(brew --prefix)/bin"
+        GF_LIBDIR="$(dirname "$("$GF/gfortran-$GCCVER" -print-file-name=libgfortran.dylib)")"
+        mkdir build && cd build
+        ../configure \
+          CC="$GF/gcc-$GCCVER" CXX="$GF/g++-$GCCVER" FC="$GF/gfortran-$GCCVER" \
+          BLAS_LIBS="-L$(brew --prefix openblas)/lib -lopenblas" \
+          CPPFLAGS="-I$(brew --prefix superlu)/include -I$(brew --prefix qhull)/include -I$(brew --prefix openblas)/include" \
+          LDFLAGS="-L$(brew --prefix superlu)/lib -L$(brew --prefix qhull)/lib -L$(brew --prefix openblas)/lib -L$GF_LIBDIR" \
+          --enable-superlu --enable-qhull --enable-force-singlethread-blas
+
+    - name: Assert the feature is fully disabled
+      run: |
+        cd build
+        echo "--- GETFEM_HAVE_EXODUS must be undefined ---"
+        if grep -q "define GETFEM_HAVE_EXODUS" src/getfem/getfem_arch_config.h; then
+          echo "ERROR: GETFEM_HAVE_EXODUS is defined in a default build"; exit 1
+        fi
+        echo "OK: GETFEM_HAVE_EXODUS undefined"
+        echo "--- configure must not have probed NetCDF ---"
+        # match the strings this configure.ac actually emits (AC_CHECK_HEADERS
+        # prints "checking for netcdf.h"; the link test "... provides nc_create")
+        if grep -qiE "checking for netcdf\.h|provides nc_create" config.log; then
+          echo "ERROR: NetCDF was probed in a default build"; exit 1
+        fi
+        echo "OK: NetCDF never probed"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.23)
 include(CheckIncludeFile)
 include(CheckIncludeFileCXX)
 include(CheckCXXSourceCompiles)
+include(CheckCXXSourceRuns)
 include(CheckLibraryExists)
 
 string(ASCII 27 ESC)
@@ -35,6 +36,7 @@ option(ENABLE_MATLAB "Enable MATLAB support" OFF)
 option(ENABLE_OPENMP "Enable OpenMP support" OFF)
 # Configure option to enable Qhull support
 option(ENABLE_QHULL "Enable Qhull support" ON)
+option(ENABLE_EXODUS "Enable Exodus II import/export support through NetCDF" OFF)
 # Configure options for enabling/disabling linear solvers (at least one is required)
 option(ENABLE_SUPERLU "Enable SuperLU support" ON) # might be turned off by cmake if SuperLU is not found
 option(ENABLE_MUMPS "Enable MUMPS support" ON)     # might be turned off by cmake if MUMPS is not found
@@ -212,6 +214,62 @@ if(NOT ENABLE_MUMPS AND NOT ENABLE_SUPERLU)
           "Use MUMPS_LIB_DIR, MUMPS_INC_DIR, SUPERLU_LIB_DIR and SUPERLU_INC_DIR")
 endif()
 
+if(ENABLE_EXODUS)
+  if(NETCDF_INC_DIR)
+    find_path(NETCDF_INCLUDE_DIR NAMES netcdf.h
+              PATHS ${NETCDF_INC_DIR} NO_DEFAULT_PATH)
+  else()
+    find_path(NETCDF_INCLUDE_DIR NAMES netcdf.h)
+  endif()
+  if(NETCDF_LIB_DIR)
+    find_library(NETCDF_LIBRARY NAMES netcdf
+                 PATHS ${NETCDF_LIB_DIR} NO_DEFAULT_PATH)
+  else()
+    find_library(NETCDF_LIBRARY NAMES netcdf)
+  endif()
+  if(NETCDF_INCLUDE_DIR AND NETCDF_LIBRARY)
+    set(GETFEM_HAVE_EXODUS 1)
+    message(STATUS "Building with Exodus II support")
+    message(STATUS "NETCDF_INCLUDE_DIR = ${NETCDF_INCLUDE_DIR}")
+    message(STATUS "NETCDF_LIBRARY = ${NETCDF_LIBRARY}")
+    set(_GETFEM_SAVE_CMAKE_REQUIRED_INCLUDES ${CMAKE_REQUIRED_INCLUDES})
+    set(_GETFEM_SAVE_CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES})
+    set(CMAKE_REQUIRED_INCLUDES ${NETCDF_INCLUDE_DIR})
+    set(CMAKE_REQUIRED_LIBRARIES ${NETCDF_LIBRARY})
+    check_cxx_source_runs("
+      #include <cstdio>
+      #include <netcdf.h>
+      int main() {
+        const char *fname = \"getfem_netcdf4_probe.nc\";
+        int ncid = -1, dimid = -1, varid = -1;
+        int st = nc_create(fname, NC_CLOBBER | NC_NETCDF4 | NC_CLASSIC_MODEL,
+                           &ncid);
+        if (st == NC_NOERR) st = nc_def_dim(ncid, \"n\", 1, &dimid);
+        if (st == NC_NOERR) st = nc_def_var(ncid, \"x\", NC_DOUBLE, 1,
+                                            &dimid, &varid);
+        if (st == NC_NOERR) st = nc_def_var_deflate(ncid, varid, 1, 1, 1);
+        if (ncid >= 0) nc_close(ncid);
+        std::remove(fname);
+        return st == NC_NOERR ? 0 : 1;
+      }" GETFEM_HAVE_EXODUS_NETCDF4)
+    set(CMAKE_REQUIRED_INCLUDES ${_GETFEM_SAVE_CMAKE_REQUIRED_INCLUDES})
+    set(CMAKE_REQUIRED_LIBRARIES ${_GETFEM_SAVE_CMAKE_REQUIRED_LIBRARIES})
+    if(GETFEM_HAVE_EXODUS_NETCDF4)
+      message(STATUS "NetCDF4/HDF5 deflate support found for Exodus compression")
+    else()
+      message(WARNING "NetCDF was found, but NetCDF4/HDF5 deflate support was "
+                      "not usable; Exodus output will default to classic "
+                      "64-bit-offset files")
+    endif()
+  else()
+    message(FATAL_ERROR
+            "ENABLE_EXODUS requires NetCDF C headers and library. "
+            "Use NETCDF_INC_DIR and NETCDF_LIB_DIR to help cmake find them.")
+  endif()
+else()
+  message("Building with Exodus II support explicitly disabled")
+endif()
+
 # define source files and main build target
 set(SOURCES
     src/bgeot_convex_ref.cc
@@ -291,6 +349,10 @@ set(SOURCES
     src/getfem_projected_fem.cc
     src/getfem_regular_meshes.cc
     src/getfem_torus.cc)
+
+if(ENABLE_EXODUS)
+  list(APPEND SOURCES src/getfem_exodus.cc)
+endif()
 
 set(HEADERS
     src/gmm/gmm_algobase.h
@@ -394,6 +456,7 @@ set(HEADERS
     src/getfem/getfem_deformable_mesh.h
     src/getfem/getfem_derivatives.h
     src/getfem/getfem_error_estimate.h
+    src/getfem/getfem_exodus.h
     src/getfem/getfem_export.h
     src/getfem/getfem_fem_global_function.h
     src/getfem/getfem_fem.h
@@ -469,6 +532,10 @@ endif()
 if(ENABLE_MUMPS)
   target_include_directories(libgetfem PRIVATE ${MUMPS_INCLUDE_PATH})
   target_link_libraries(libgetfem PUBLIC "${MUMPS_LIBS}")
+endif()
+if(ENABLE_EXODUS)
+  target_include_directories(libgetfem PRIVATE ${NETCDF_INCLUDE_DIR})
+  target_link_libraries(libgetfem PRIVATE ${NETCDF_LIBRARY})
 endif()
 
 if(NOT GETFEM_PARA_LEVEL MATCHES "^(0|1|2)$")

--- a/cmake/getfem_arch_config.h.in
+++ b/cmake/getfem_arch_config.h.in
@@ -16,6 +16,12 @@
 /* glibc floating point exceptions control */
 #cmakedefine GETFEM_HAVE_FEENABLEEXCEPT
 
+/* defined if GetFEM is built with Exodus II / NetCDF support */
+#cmakedefine GETFEM_HAVE_EXODUS
+
+/* defined if NetCDF supports NetCDF4/HDF5 deflate for Exodus compression */
+#cmakedefine GETFEM_HAVE_EXODUS_NETCDF4
+
 /* defined if the <libqhull_r/qhull_ra.h> header file is available */
 #cmakedefine GETFEM_HAVE_LIBQHULL_R_QHULL_RA_H
 

--- a/configure.ac
+++ b/configure.ac
@@ -997,6 +997,94 @@ fi
 dnl ---------------------------END OF MUMPS TEST--------------------------
 
 
+dnl ------------------------------EXODUS TEST----------------------------
+dnl Exodus II file I/O. Optional and DISABLED BY DEFAULT: unless
+dnl --enable-exodus is given, NetCDF is never probed, GETFEM_HAVE_EXODUS is
+dnl left undefined (so all Exodus code is compiled out), the EXODUS automake
+dnl conditional stays false (no Exodus sources or tests are built) and no
+dnl Exodus-only dependency is linked.
+require_exodus="no"
+AC_ARG_ENABLE(exodus,
+  [AS_HELP_STRING([--enable-exodus], [Enable Exodus II file I/O (requires NetCDF). Disabled by default.])],
+  [require_exodus=$enableval],
+  [require_exodus="no"])
+
+NETCDF_LIBS=""
+found_exodus="no"
+if test "x$require_exodus" = "xno"; then
+  echo "Building without Exodus II support (use --enable-exodus to enable it)"
+else
+  NETCDF_LIBS="-lnetcdf"
+  AC_ARG_WITH(netcdf,
+   [AS_HELP_STRING([--with-netcdf=<lib>],[use the NetCDF library <lib> for Exodus support])],
+   [case $with_netcdf in
+     yes | "" ) ;;
+     -* | */* | *.a | *.so | *.so.* | *.o | *.dylib ) NETCDF_LIBS="$with_netcdf";;
+     * ) NETCDF_LIBS=`echo $with_netcdf | sed -e 's/^/-l/g;s/ \+/ -l/g'`;;
+    esac]
+  )
+  NETCDFINC=""
+  AC_ARG_WITH(netcdf-include-dir,
+   [AS_HELP_STRING([--with-netcdf-include-dir],[directory in which netcdf.h can be found])],
+   [case $withval in
+     -I* ) NETCDFINC="$withval";;
+     * ) NETCDFINC="-I$withval";;
+    esac],
+  )
+  CPPFLAGS="$CPPFLAGS $NETCDFINC"
+
+  save_LIBS="$LIBS"
+  AC_CHECK_HEADERS([netcdf.h], [],
+    [AC_MSG_ERROR([--enable-exodus was given but netcdf.h was not found (try --with-netcdf-include-dir=<dir>)])])
+  dnl NETCDF_LIBS may be bare names ("-lnetcdf"), a full library path, or
+  dnl "-L<dir> -lnetcdf" flags; link with it directly rather than feeding it to
+  dnl AC_SEARCH_LIBS (which expects bare library names and would mangle paths/flags).
+  LIBS="$NETCDF_LIBS $save_LIBS"
+  AC_MSG_CHECKING([whether NetCDF ($NETCDF_LIBS) provides nc_create])
+  dnl extern "C": this runs in the C++ language, but nc_create is a C symbol
+  AC_LINK_IFELSE([AC_LANG_PROGRAM([[extern "C" char nc_create ();]], [[return nc_create ();]])],
+    [found_exodus="yes"; AC_MSG_RESULT([yes])],
+    [found_exodus="no";  AC_MSG_RESULT([no])])
+  LIBS="$save_LIBS"
+  if test x"$found_exodus" = x"yes"; then
+    AC_DEFINE(GETFEM_HAVE_EXODUS,1,[defined if GetFEM is built with Exodus II file support])
+    LIBS="$NETCDF_LIBS $save_LIBS"
+    AC_MSG_CHECKING([whether NetCDF supports NetCDF4 deflate])
+    AC_RUN_IFELSE([AC_LANG_PROGRAM([[
+#include <cstdio>
+#include <netcdf.h>
+    ]], [[
+      const char *fname = "getfem_netcdf4_probe.nc";
+      int ncid = -1, dimid = -1, varid = -1;
+      int st = nc_create(fname, NC_CLOBBER | NC_NETCDF4 | NC_CLASSIC_MODEL,
+                         &ncid);
+      if (st == NC_NOERR) st = nc_def_dim(ncid, "n", 1, &dimid);
+      if (st == NC_NOERR) st = nc_def_var(ncid, "x", NC_DOUBLE, 1,
+                                          &dimid, &varid);
+      if (st == NC_NOERR) st = nc_def_var_deflate(ncid, varid, 1, 1, 1);
+      if (ncid >= 0) nc_close(ncid);
+      std::remove(fname);
+      return st == NC_NOERR ? 0 : 1;
+    ]])],
+      [AC_MSG_RESULT([yes])
+       AC_DEFINE(GETFEM_HAVE_EXODUS_NETCDF4,1,[defined if NetCDF supports NetCDF4/HDF5 deflate for Exodus compression])],
+      [AC_MSG_RESULT([no])
+       AC_MSG_WARN([NetCDF was found, but NetCDF4/HDF5 deflate was not usable; Exodus output will default to classic 64-bit-offset files])],
+      [AC_MSG_RESULT([unknown])
+       AC_MSG_WARN([cross compiling: cannot test NetCDF4 deflate; Exodus output will default to classic 64-bit-offset files])])
+    LIBS="$NETCDF_LIBS $save_LIBS"
+    echo "Building with Exodus II support"
+  else
+    AC_MSG_ERROR([--enable-exodus was given but linking nc_create from NetCDF ($NETCDF_LIBS) failed (try --with-netcdf=<lib>, --with-netcdf-include-dir=<dir>, or set LDFLAGS)])
+  fi
+fi
+AM_CONDITIONAL(EXODUS, test x$found_exodus = xyes)
+AC_SUBST([NETCDF_LIBS])
+if test "x$found_exodus" = "xyes"; then
+  echo "Configuration of Exodus done"
+fi
+dnl ---------------------------END OF EXODUS TEST------------------------
+
 
 if test "x$found_superlu" = "xno" -a "x$found_mumps" = "xno"; then
   AC_MSG_ERROR([Neither MUMPS nor SuperLU was enabled. At least one linear solver is required.])

--- a/doc/sphinx/source/userdoc/export.rst
+++ b/doc/sphinx/source/userdoc/export.rst
@@ -53,6 +53,11 @@ The corresponding four classes: |gf_vtk_export|, |gf_vtu_export|,
 
 Examples of use can be found in the examples of the tests directory.
 
+In addition, if |gf| is configured with ``--enable-exodus``, the `Exodus II
+<https://sandialabs.github.io/seacas-docs/>`_ format can be used to export and
+re-import a |gf_m| or |gf_mf| (including transient results); see
+:ref:`ud-export-exodus` below.
+
 .. _ud-export_slices:
 
 Producing mesh slices
@@ -284,3 +289,143 @@ exported (into another OpenDX mesh). In this example, you have access in OpenDX 
 The ``tests/dynamic_friction.net`` is an example of OpenDX program for these data
 (run it with ``cd tests; dx -edit dynamic_friction.net`` , menu
 "Execute/sequencer").
+
+.. _ud-export-exodus:
+
+Exodus II export and import
+---------------------------
+
+The `Exodus II <https://sandialabs.github.io/seacas-docs/>`_ format (defined by
+Sandia's SEACAS project) is a finite-element database built on top of `NetCDF
+<https://www.unidata.ucar.edu/software/netcdf/>`_. It stores a mesh together
+with optional nodal results and, unlike the formats above, a single file
+natively holds a transient (time-dependent) series.
+
+|gf| support for Exodus is **optional**: it is only compiled when the library is
+configured with ``--enable-exodus``, which requires the NetCDF library and
+headers (the SEACAS library itself is *not* needed — the documented Exodus
+layout is written directly through NetCDF). The classes ``getfem::exodus_export``
+and ``getfem::exodus_import`` are declared in :file:`getfem/getfem_exodus.h`.
+
+Writing a mesh and some fields is similar to the other exporters::
+
+  #include "getfem/getfem_exodus.h"
+  ...
+  getfem::exodus_export exp("output.exo");
+  exp.exporting(mf);                  // a mesh_fem (or a mesh)
+  exp.write_mesh();
+  exp.write_point_data(mf, U, "displacement");
+
+As with the VTK export, the finite element and geometric transformations are
+mapped to order 1 or 2 isoparametric Pk/Qk elements. The supported element types
+are segments, triangles, quadrilaterals, tetrahedra, hexahedra and prisms (linear
+and quadratic), written as the matching Exodus element types (``BAR2``/``BAR3``,
+``TRI3``/``TRI6``, ``QUAD4``/``QUAD8``/``QUAD9``, ``TETRA4``/``TETRA10``,
+``HEX8``/``HEX20``/``HEX27``, ``WEDGE6``/``WEDGE15``).
+
+A transient series is written to a single file by opening a new time step before
+writing each field::
+
+  getfem::exodus_export exp("output.exo");
+  exp.exporting(mf);
+  exp.write_mesh();
+  while (t <= T) {
+    ...
+    exp.set_time(t);                  // open a new time step at value t
+    exp.write_point_data(mf, U, "u");
+    exp.sync();                       // optional: flush this complete step
+  }
+  // the file is finalised when exp goes out of scope (or on exp.close())
+
+Calling ``sync()`` after all fields for a time step have been written flushes the
+completed step to disk. This is useful for long-running simulations: ParaView can
+reload/refresh the same file and see the synced time steps while the simulation
+continues. Incomplete steps are rejected instead of being deliberately synced
+with fill values.
+
+For best write performance when the list of result fields is known up front,
+predeclare them before ``write_mesh()``::
+
+  getfem::exodus_export exp("output.exo");
+  exp.exporting(mf);
+  exp.declare_point_data("u", mf.get_qdim());
+  exp.write_mesh();
+
+This lets the exporter create the transient variables during the initial NetCDF
+definition phase and avoids a later file redefine. The Python/Matlab interface
+uses this path automatically for ``export_to_exodus`` calls that create a new
+file.
+
+Appending time steps is supported only for files written by GetFEM with the same
+exported mesh. New files store a compact GetFEM mesh fingerprint (dimension,
+node coordinates, block layout and connectivity); append mode checks it before
+writing so that a result cannot be appended to a file with a different block or
+element layout.
+
+|gf| regions are exported as Exodus sets, keyed by the region number: the face
+entries of a region become a *side set*, its whole-convex entries become an
+*element set*, and the nodes it touches become a *node set*. In addition, each
+volume (whole-convex) region is written as its own Exodus *element block* whose
+block id equals the region number, so a viewer such as ParaView can colour the
+regions by the block id (``ObjectId``) or with ``vtkBlockColors``.
+
+``enable_region_field()`` in C++ (or the ``'region field'`` keyword of the Python
+``export_to_exodus``) additionally writes a ``region`` element (cell) variable
+holding that block id per element, which gives a discrete cell field to colour
+by. It is **off by default**: being constant in time, it would otherwise be
+stored at every transient step. If it is explicitly enabled for a mesh-only
+export, GetFEM writes one static Exodus time step containing only this cell
+variable.
+
+When GetFEM is built with usable NetCDF4/HDF5 deflate support, the Exodus writer
+creates **compressed** NetCDF4 classic-model files by default (deflated numeric
+arrays), which substantially reduces the size of large meshes and transient
+series. Such files are still valid Exodus II and are read transparently by any
+reader built with NetCDF4/HDF5 support, including modern ParaView. If that
+support is not available at configure time, GetFEM defaults to classic
+64-bit-offset files. To force classic output — for the widest reader
+compatibility, or for very small meshes where the HDF5 container overhead can
+make a compressed file *larger* — pass ``enable_compression(0)`` in C++ or the
+``'uncompressed'`` keyword in the interface. The deflate level (1..9) can be set
+with ``enable_compression(level)`` on builds with NetCDF4/HDF5 support.
+Compression is fixed when the file is created and cannot be changed on
+``append``.
+
+By default, region blocks are named ``region_<id>`` and set names are left
+empty. Names can be set explicitly with ``exp.set_region_name(id, "name")`` in
+C++, or with the ``'region names'`` option of the Python ``export_to_exodus`` (an
+id vector and a list of names of the same length).
+
+When *importing* externally produced files, both the split (``coordx``/``coordy``/
+``coordz``) and the older packed (``coord``) coordinate layouts are read, and
+connectivity node ids are range-checked. Shell elements (``SHELL*``) are read as
+2D surface elements. Side sets defined on shell elements are rejected with a clear
+error because their top/bottom-face numbering differs from a 2D quad's edge
+numbering.
+
+The mesh is read back with ``getfem::import_mesh`` (side sets are restored as
+face regions and element sets as convex regions)::
+
+  getfem::mesh m;
+  getfem::import_mesh("output.exo", "exodus", m);
+
+The transient nodal variables can also be read back, which makes an
+export/import round-trip verifiable::
+
+  getfem::exodus_import imp("output.exo");
+  getfem::mesh m;  imp.read_mesh(m);
+  std::vector<double> U;
+  imp.read_nodal_var("u", step, U);   // values at time step ``step``
+
+The Python interface exposes the same operations:
+
+.. code-block:: python
+
+   mf.export_to_exodus('output.exo', U, 'u')        # compressed when supported
+   mf.export_to_exodus('plain.exo', 'uncompressed', U, 'u')   # force classic
+   # optionally name the blocks/sets matching regions 1 and 2:
+   mf.export_to_exodus('named.exo', 'region names', [1, 2], ['left', 'right'], U, 'u')
+   # request NetCDF4 compression when creating a new file:
+   mf.export_to_exodus('small.exo', 'compress', U, 'u')
+   m2 = gf.Mesh('import', 'exodus', 'output.exo')
+   vals = m2.exodus_nodal_data('output.exo', 'u', 0)

--- a/interface/src/gf_mesh_fem_get.cc
+++ b/interface/src/gf_mesh_fem_get.cc
@@ -21,6 +21,7 @@
 
 #include <getfem/getfem_fem.h>
 #include <getfem/getfem_export.h>
+#include <getfem/getfem_exodus.h>
 #include <getfem/getfem_mesh_fem_level_set.h>
 #include <getfem/getfem_mesh_im.h>
 #include <getfem/getfem_partial_mesh_fem.h>
@@ -784,6 +785,115 @@ build_sub_command_table(std::map<std::string, psub_command> &subc_tab) {
        count+=1;
      }
      );
+
+  /*@GET ('export to exodus',@str filename, ... ['region field']['uncompressed']['compress']['region names', @ivec ids, @list names][,'append'][,'time', @scalar t], U, 'name'...)
+    Export a @tmf and some nodal fields to an Exodus II file (requires GetFEM
+    built with --enable-exodus).
+
+    The FEM and geometric transformations are mapped to order 1 or 2
+    isoparametric Pk (or Qk) FEMs, as with the VTK export. GetFEM regions are
+    written as Exodus side sets (faces), element sets (convexes) and node sets;
+    in addition each volume region becomes an element block (so a viewer such as
+    ParaView can colour the regions by block id / ObjectId). The nodal fields
+    can be read back with MESH:GET('exodus nodal data').
+
+    Pass 'region field' to also write a ``region`` element (cell) variable
+    holding each element's block id; this is off by default because, being
+    time-constant, it would otherwise be stored at every transient step.
+    New files are written compressed (NetCDF4 classic-model) by default when
+    GetFEM was built with usable NetCDF4/HDF5 deflate support; otherwise they
+    default to classic 64-bit-offset output. Pass 'uncompressed' to force
+    classic output; pass 'compress' to request NetCDF4 compression explicitly.
+    Compression cannot be changed on 'append'.
+
+    With "'region names', ids, names" -- an integer region-id vector and a list
+    of strings of the same length -- the matching blocks/side sets/element
+    sets/node sets are named accordingly. Without it, region blocks are named
+    ``region_<id>`` and set names are left empty::
+
+      mf.export_to_exodus('b.exo', 'region names', [1,2,3], ['left','mid','right'], U, 'u')
+
+    For a transient result, call this once to create the file (optionally with
+    "'time', t" for the first step), then once per following step with the
+    'append' option; each 'append' reopens the file and appends one time step,
+    so a long run is written incrementally without keeping the whole history in
+    memory::
+
+      mf.export_to_exodus('r.exo', 'time', 0.0, U0, 'u')
+      mf.export_to_exodus('r.exo', 'append', 'time', 1.0, U1, 'u')@*/
+#ifdef GETFEM_HAVE_EXODUS
+  sub_command
+    ("export to exodus", 0, -1, 0, 0,
+     std::string fname = in.pop().to_string();
+     bool append = false; bool has_time = false; double tval = 0.;
+     bool region_field = false; bool compress = false; bool uncompressed = false;
+     std::vector<int> rg_ids;            // (parallel vectors: a pair<> would put a
+     std::vector<std::string> rg_names;  //  comma at the top level of the macro body)
+     while (in.remaining() && in.front().is_string()) {
+       std::string kw = in.pop().to_string();
+       if (cmd_strmatch(kw, "append")) append = true;
+       else if (cmd_strmatch(kw, "region field")) region_field = true;
+       else if (cmd_strmatch(kw, "compress")) compress = true;
+       else if (cmd_strmatch(kw, "uncompressed")) uncompressed = true;
+       else if (cmd_strmatch(kw, "time")) { tval = in.pop().to_scalar(); has_time = true; }
+       else if (cmd_strmatch(kw, "region names")) {
+         if (in.remaining() < 2)
+           THROW_BADARG("'region names' expects an id vector and a name list");
+         iarray ids = in.pop().to_iarray();
+         const gfi_array *na = in.pop().arg;
+         mexargs_in names_in(1, &na, true);
+         GMM_ASSERT1(ids.size() == size_type(names_in.remaining()),
+                     "'region names': id vector and name list differ in length");
+         for (size_type i=0; i < ids.size(); ++i) {
+           rg_ids.push_back(int(ids[i]));
+           rg_names.push_back(names_in.pop().to_string());
+         }
+       }
+       else THROW_BADARG("expecting 'append', 'time', 'region field', 'compress', "
+                         "'uncompressed' or 'region names', got " << kw);
+     }
+     if (append && (compress || uncompressed))
+       THROW_BADARG("compression cannot be changed on 'append' (it is fixed when "
+                    "the file is created)");
+     getfem::exodus_export exp(fname, append);
+     if (uncompressed) exp.enable_compression(0);
+     else if (compress) exp.enable_compression();
+     if (region_field) exp.enable_region_field();
+     for (size_type i=0; i < rg_ids.size(); ++i)
+       exp.set_region_name(rg_ids[i], rg_names[i]);
+     exp.exporting(*mf);
+     std::vector<const getfem::mesh_fem *> data_mf;
+     std::vector<darray> data_u;
+     std::vector<std::string> data_name;
+     int count = 1;
+     while (in.remaining()) {
+       const getfem::mesh_fem *mf2 = mf;
+       if (in.remaining() >= 2 && is_meshfem_object(in.front()))
+         mf2 = to_meshfem_object(in.pop());
+       darray U = in.pop().to_darray();
+       in.last_popped().check_trailing_dimension(int(mf2->nb_dof()));
+       std::string nm = get_vtk_dataset_name(in, count);
+       if (!append) {
+         size_type Q = (U.size() / mf2->nb_dof()) * mf2->get_qdim();
+         exp.declare_point_data(nm, Q);
+       }
+       data_mf.push_back(mf2); data_u.push_back(U); data_name.push_back(nm);
+       count+=1;
+     }
+     if (!append) exp.write_mesh();
+     if (append || has_time) exp.set_time(tval);
+     for (size_type i=0; i < data_u.size(); ++i)
+       exp.write_point_data(*data_mf[i], data_u[i], data_name[i]);
+     exp.close();   // explicit (not via destructor) so a per-step completeness
+                    // error is reported to the caller instead of being swallowed
+     );
+#else
+  sub_command
+    ("export to exodus", 0, -1, 0, 0,
+     THROW_BADARG("GetFEM was built without Exodus support; reconfigure with "
+                  "--enable-exodus");
+     );
+#endif
 
 
   /*@GET ('export to dx',@str filename, ...['as', @str mesh_name][,'edges']['serie',@str serie_name][,'ascii'][,'append'], U, 'name'...)

--- a/interface/src/gf_mesh_get.cc
+++ b/interface/src/gf_mesh_get.cc
@@ -21,6 +21,7 @@
 #include <map>
 #include <getfemint_misc.h>
 #include <getfem/getfem_export.h>
+#include <getfem/getfem_exodus.h>
 #include <getfem/getfem_mesh.h>
 
 using namespace getfemint;
@@ -1235,6 +1236,87 @@ build_sub_command_table(std::map<std::string, psub_command> &subc_tab) {
      exp.exporting(*pmesh);
      exp.write_mesh(); if (write_q) exp.write_mesh_quality(*pmesh);
      );
+
+  /*@GET ('export to exodus', @str filename, ... ['region field']['uncompressed']['compress']['region names', @ivec ids, @list names])
+    Exports a mesh to an Exodus II file (requires GetFEM built with
+    --enable-exodus).
+
+    With "'region names', ids, names" the Exodus blocks/side sets/element
+    sets/node sets matching those region ids are named accordingly. Without it,
+    region blocks are named ``region_<id>`` and set names are left empty. Pass
+    'region field' to also write a ``region`` element variable holding each
+    element's block id (for colouring by id).
+    Files are written compressed (NetCDF4 classic-model) by default when GetFEM
+    was built with usable NetCDF4/HDF5 deflate support; otherwise they default
+    to classic 64-bit-offset output. Pass 'uncompressed' to force classic output.
+
+    See also MESH_FEM:GET('export to exodus').@*/
+#ifdef GETFEM_HAVE_EXODUS
+  sub_command
+    ("export to exodus", 1, -1, 0, 1,
+     std::string fname = in.pop().to_string();
+     getfem::exodus_export exp(fname);
+     while (in.remaining() && in.front().is_string()) {
+       std::string kw = in.pop().to_string();
+       if (cmd_strmatch(kw, "region field")) exp.enable_region_field();
+       else if (cmd_strmatch(kw, "compress")) exp.enable_compression();
+       else if (cmd_strmatch(kw, "uncompressed")) exp.enable_compression(0);
+       else if (cmd_strmatch(kw, "region names")) {
+         if (in.remaining() < 2)
+           THROW_BADARG("'region names' expects an id vector and a name list");
+         iarray ids = in.pop().to_iarray();
+         const gfi_array *na = in.pop().arg;
+         mexargs_in names_in(1, &na, true);
+         GMM_ASSERT1(ids.size() == size_type(names_in.remaining()),
+                     "'region names': id vector and name list differ in length");
+         for (size_type i=0; i < ids.size(); ++i)
+           exp.set_region_name(int(ids[i]), names_in.pop().to_string());
+       }
+       else THROW_BADARG("expecting 'region field', 'compress', 'uncompressed' "
+                         "or 'region names', got " << kw);
+     }
+     exp.exporting(*pmesh);
+     exp.write_mesh();
+     exp.close();
+     );
+#else
+  sub_command
+    ("export to exodus", 1, -1, 0, 1,
+     THROW_BADARG("GetFEM was built without Exodus support; reconfigure with "
+                  "--enable-exodus");
+     );
+#endif
+
+
+  /*@GET V = ('exodus nodal data', @str filename, @str varname[, @int step])
+    Reads a nodal variable from an Exodus II file (requires GetFEM built with
+    --enable-exodus).
+
+    Returns the values of nodal variable `varname` at time step `step`
+    (0-based, default 0), ordered by Exodus node number. When the mesh was
+    imported from the same file with MESH:INIT('import', 'exodus', ...), value
+    `i` corresponds to mesh point `i`.@*/
+#ifdef GETFEM_HAVE_EXODUS
+  sub_command
+    ("exodus nodal data", 2, 3, 0, 1,
+     (void)pmesh;
+     std::string fname = in.pop().to_string();
+     std::string vname = in.pop().to_string();
+     size_type step = in.remaining()
+       ? size_type(in.pop().to_integer(0, INT_MAX)) : size_type(0);
+     getfem::exodus_import imp(fname);
+     std::vector<double> vals;
+     imp.read_nodal_var(vname, step, vals);
+     out.pop().from_dcvector(vals);
+     );
+#else
+  sub_command
+    ("exodus nodal data", 2, 3, 0, 1,
+     (void)pmesh;
+     THROW_BADARG("GetFEM was built without Exodus support; reconfigure with "
+                  "--enable-exodus");
+     );
+#endif
 
 
   /*@GET ('export to vtu', @str filename, ... [,'ascii'][,'quality'])

--- a/interface/tests/python/Makefile.am
+++ b/interface/tests/python/Makefile.am
@@ -22,9 +22,16 @@ else
 optpy =
 endif
 
+if EXODUS
+optpy_exodus = check_exodus.py
+else
+optpy_exodus =
+endif
+
 
 EXTRA_DIST=                                       \
     check_export.py                               \
+    check_exodus.py                               \
     check_export_vtu.py                           \
     check_global_functions.py                     \
     check_levelset.py                             \
@@ -84,12 +91,13 @@ TESTS =                         \
     demo_laplacian.py           \
     demo_laplacian_HHO.py       \
     demo_elasticity_HHO.py      \
-    $(optpy)
+    $(optpy)                    \
+    $(optpy_exodus)
 
 AM_TESTS_ENVIRONMENT = \
-    export PYTHONPATH=$(PYTHONPATH):$(top_builddir)/interface/src/python; \
+    export PYTHONPATH=$(top_builddir)/interface/src/python:$(PYTHONPATH); \
     export LD_LIBRARY_PATH=$(LD_LIBRARY_PATH):$(top_builddir)/src/.libs;
 LOG_COMPILER = $(PYTHON)
 endif
 
-CLEANFILES = *.vtk *.vtu *.dx *.pyc tank_3D* tripod* plate* *.pos *.dx results/* __pycache__/*
+CLEANFILES = *.vtk *.vtu *.dx *.pyc tank_3D* tripod* plate* *.pos *.dx *.exo results/* __pycache__/*

--- a/interface/tests/python/check_exodus.py
+++ b/interface/tests/python/check_exodus.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Python GetFEM interface
+#
+# Copyright (C) 2026 GetFEM contributors.
+#
+# This file is a part of GetFEM
+#
+# GetFEM  is  free software;  you  can  redistribute  it  and/or modify it
+# under  the  terms  of the  GNU  Lesser General Public License as published
+# by  the  Free Software Foundation;  either version 2.1 of the License,  or
+# (at your option) any later version.
+# This program  is  distributed  in  the  hope  that it will be useful,  but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or  FITNESS  FOR  A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+# License for more details.
+# You  should  have received a copy of the GNU Lesser General Public License
+# along  with  this program;  if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+############################################################################
+"""  Test the Exodus II import/export of the python-getfem interface.
+
+  Writes a mesh and a nodal field to an Exodus file, reads them back, and
+  checks the geometry and the field values are recovered. Requires GetFEM
+  built with --enable-exodus.
+
+  $Id$
+"""
+import numpy as np
+import getfem as gf
+
+NX = 4
+errors = 0
+
+
+def check(cond, msg):
+    global errors
+    if not cond:
+        errors += 1
+        print("  *** error has been detected: " + msg)
+
+
+def field(P):
+    # P is a 1D coordinate array
+    v = 1.0 + 2.0 * P[0] + 0.3 * P[0] ** 2
+    if P.size > 1:
+        v += 3.0 * P[1] - 0.2 * P[1] ** 2
+    if P.size > 2:
+        v += 4.0 * P[2]
+    return v
+
+
+def make_mesh(kind):
+    x = np.arange(0.0, 1.0 + 1e-9, 1.0 / NX)
+    if kind == "tri":
+        return gf.Mesh("regular_simplices", x, x)
+    elif kind == "quad":
+        return gf.Mesh("cartesian", x, x)
+    elif kind == "tet":
+        return gf.Mesh("regular_simplices", x, x, x)
+    elif kind == "hex":
+        return gf.Mesh("cartesian", x, x, x)
+    raise ValueError(kind)
+
+
+def roundtrip(kind, order):
+    tag = "%s (order %d)" % (kind, order)
+    fname = "check_exodus_%s_%d.exo" % (kind, order)
+    m = make_mesh(kind)
+    mf = gf.MeshFem(m, 1)
+    mf.set_classical_fem(order)
+
+    coords = mf.basic_dof_nodes()              # (dim, nbdof)
+    U = np.array([field(coords[:, i]) for i in range(coords.shape[1])])
+
+    mf.export_to_exodus(fname, U, "u")
+
+    # read the mesh back through getfem
+    m2 = gf.Mesh("import", "exodus", fname)
+    check(m2.nbcvs() == m.nbcvs(), tag + ": number of elements")
+    check(m2.dim() == m.dim(), tag + ": dimension")
+
+    # read the field back through getfem and compare at every node
+    vals = np.asarray(m2.exodus_nodal_data(fname, "u", 0)).ravel()
+    pts = m2.pts()                             # (dim, nbpt), node i == point i
+    check(vals.size == pts.shape[1], tag + ": variable length")
+    err = 0.0
+    for i in range(vals.size):
+        err = max(err, abs(vals[i] - field(pts[:, i])))
+    check(err < 1e-10, tag + ": field values (err=%g)" % err)
+    print("  %s: %d elements, %d nodes, value error %g"
+          % (tag, m2.nbcvs(), vals.size, err))
+
+
+def region_roundtrip(kind):
+    # a boundary face region must survive export (as an Exodus side set) and
+    # import (back to a getfem face region)
+    fname = "check_exodus_reg_%s.exo" % kind
+    m = make_mesh(kind)
+    m.set_region(7, m.outer_faces())
+    n_orig = np.asarray(m.region(7)).shape[1]
+    m.export_to_exodus(fname)
+    m2 = gf.Mesh("import", "exodus", fname)
+    present = 7 in list(m2.regions())
+    check(present, "%s region: present" % kind)
+    n_imp = np.asarray(m2.region(7)).shape[1] if present else 0
+    check(n_imp == n_orig, "%s region: boundary face count (%d vs %d)"
+          % (kind, n_imp, n_orig))
+    print("  %s region: %d/%d boundary faces round-tripped"
+          % (kind, n_imp, n_orig))
+
+
+def volume_region_roundtrip(kind):
+    # a convex (volume) region must survive export (Exodus element set) and
+    # import (back to a getfem convex region)
+    fname = "check_exodus_vol_%s.exo" % kind
+    m = make_mesh(kind)
+    m.set_region(5, m.cvid())          # all convexes -> region 5
+    n_orig = m.nbcvs()
+    m.export_to_exodus(fname)
+    m2 = gf.Mesh("import", "exodus", fname)
+    present = 5 in list(m2.regions())
+    check(present, "%s volume region: present" % kind)
+    n_imp = np.asarray(m2.region(5)).shape[1] if present else 0
+    check(n_imp == n_orig, "%s volume region: convex count (%d vs %d)"
+          % (kind, n_imp, n_orig))
+    print("  %s volume region: %d/%d convexes round-tripped"
+          % (kind, n_imp, n_orig))
+
+
+def streaming_roundtrip():
+    # incremental transient export: the first call creates the file, each later
+    # call appends one step (no rewrite); re-read every step and check the values
+    fname = "check_exodus_stream.exo"
+    m = make_mesh("quad")
+    mf = gf.MeshFem(m, 1); mf.set_classical_fem(1)
+    P = mf.basic_dof_nodes()
+    times = [0.0, 0.5, 1.0, 1.5]
+    for k, t in enumerate(times):
+        U = np.array([(1.0 + t) * field(P[:, i]) for i in range(P.shape[1])])
+        if k == 0:
+            mf.export_to_exodus(fname, "time", t, U, "u")
+        else:
+            mf.export_to_exodus(fname, "append", "time", t, U, "u")
+
+    m2 = gf.Mesh("import", "exodus", fname)
+    pts = m2.pts()
+    err = 0.0
+    for k, t in enumerate(times):
+        vals = np.asarray(m2.exodus_nodal_data(fname, "u", k)).ravel()
+        expv = np.array([(1.0 + t) * field(pts[:, i]) for i in range(pts.shape[1])])
+        err = max(err, np.max(np.abs(vals - expv)))
+    check(err < 1e-10, "incremental append: %d steps (err=%g)" % (len(times), err))
+    print("  incremental append (export_to_exodus 'append'): %d steps, value error %g"
+          % (len(times), err))
+
+
+def independent_reader_check():
+    # confirm the written file is genuine Exodus, read by an independent
+    # NetCDF reader (skipped if scipy is unavailable)
+    try:
+        from scipy.io import netcdf_file
+    except Exception:
+        print("  (scipy not available, skipping independent-reader check)")
+        return
+    m = make_mesh("quad")
+    m.set_region(3, m.outer_faces())   # boundary -> side set + node set
+    mf = gf.MeshFem(m, 1)
+    mf.set_classical_fem(2)
+    coords = mf.basic_dof_nodes()
+    U = np.array([field(coords[:, i]) for i in range(coords.shape[1])])
+    # 'uncompressed' so the classic-only scipy reader can open it even when the
+    # default output is compressed NetCDF4.
+    mf.export_to_exodus("check_exodus_indep.exo", "uncompressed", "region field",
+                        U, "u")
+    f = netcdf_file("check_exodus_indep.exo", "r", mmap=False)
+    et = f.variables["connect1"].elem_type
+    et = et.decode() if hasattr(et, "decode") else et
+    check(et == "QUAD9", "independent reader: elem_type (%s)" % et)
+    check(f.dimensions["num_dim"] == 2, "independent reader: num_dim")
+    check("coordx" in f.variables and "vals_nod_var1" in f.variables,
+          "independent reader: required Exodus variables present")
+    check("elem_ss1" in f.variables and "side_ss1" in f.variables,
+          "independent reader: side set present")
+    check("node_ns1" in f.variables, "independent reader: node set present")
+    # identity id maps (help ParaView's GlobalElementId / GlobalNodeId)
+    check("elem_num_map" in f.variables and "node_num_map" in f.variables,
+          "independent reader: id maps present")
+    ne = f.dimensions["num_elem"]
+    check(np.array_equal(np.asarray(f.variables["elem_num_map"][:]),
+                         np.arange(1, ne + 1)),
+          "independent reader: elem_num_map identity")
+    # the "region" element (cell) variable carrying the block id
+    check(f.dimensions["num_elem_var"] == 1,
+          "independent reader: one element variable")
+    rname = np.asarray(f.variables["name_elem_var"][0]).tobytes().split(b"\x00", 1)[0]
+    check(rname.decode("ascii", "ignore") == "region",
+          "independent reader: element var named 'region'")
+    reg = np.asarray(f.variables["vals_elem_var1eb1"][0])
+    check(np.all(reg == f.variables["eb_prop1"][0]),
+          "independent reader: region value == block id")
+    f.close()
+    print("  independent reader: valid Exodus II with side set, node set, "
+          "id maps and region cell var")
+
+
+def _exo_name(f, var, i):
+    return np.asarray(f.variables[var][i]).tobytes().split(b"\x00", 1)[0] \
+             .decode("ascii", "ignore")
+
+
+def region_names_check():
+    # the 'region names' option names the Exodus blocks and element sets
+    try:
+        from scipy.io import netcdf_file
+    except Exception:
+        return
+    m = make_mesh("hex")
+    cv = np.asarray(m.cvid()).ravel()
+    m.set_region(1, cv[0::2])               # two disjoint volume regions
+    m.set_region(2, cv[1::2])
+    mf = gf.MeshFem(m, 1); mf.set_classical_fem(1)
+    P = mf.basic_dof_nodes()
+    U = np.array([field(P[:, i]) for i in range(P.shape[1])])
+    mf.export_to_exodus("check_exodus_named.exo", "uncompressed",
+                        "region names", [1, 2], ["inner", "outer"], U, "u")
+    f = netcdf_file("check_exodus_named.exo", "r", mmap=False)
+    ebp = [int(x) for x in f.variables["eb_prop1"][:]]
+    want = {1: "inner", 2: "outer"}
+    ok = all(_exo_name(f, "eb_names", i) == want[ebp[i]] for i in range(len(ebp)))
+    check(ok, "region names: blocks named inner/outer")
+    check("els_names" in f.variables, "region names: els_names present")
+    f.close()
+    print("  region names: blocks/sets named via the 'region names' option")
+
+
+def streaming_region_check():
+    # the region cell var must be written at every (appended) time step
+    try:
+        from scipy.io import netcdf_file
+    except Exception:
+        return
+    fname = "check_exodus_stream_region.exo"
+    m = make_mesh("quad")
+    m.set_region(1, m.cvid())               # all convexes -> one volume region
+    mf = gf.MeshFem(m, 1); mf.set_classical_fem(1)
+    P = mf.basic_dof_nodes()
+    times = [0.0, 0.5, 1.0]
+    for k, t in enumerate(times):
+        U = np.array([(1.0 + t) * field(P[:, i]) for i in range(P.shape[1])])
+        if k == 0:
+            mf.export_to_exodus(fname, "uncompressed", "region field",
+                                "time", t, U, "u")
+        else:
+            mf.export_to_exodus(fname, "append", "time", t, U, "u")
+    f = netcdf_file(fname, "r", mmap=False)
+    reg = np.asarray(f.variables["vals_elem_var1eb1"][:])   # (nsteps, nelem)
+    bid = int(f.variables["eb_prop1"][0])
+    check(reg.shape[0] == len(times) and np.all(reg == bid),
+          "streaming: region cell var at every step")
+    f.close()
+    print("  streaming: region cell var written at each appended step")
+
+
+def compression_check():
+    # Default output is compressed NetCDF4 only when the build proved usable
+    # NetCDF4/HDF5 deflate support; otherwise it is classic 64-bit offset.
+    import os
+    x = np.arange(0.0, 1.0 + 1e-9, 1.0 / 12)
+    m = gf.Mesh("cartesian", x, x, x)
+    mf = gf.MeshFem(m, 1); mf.set_classical_fem(1)
+    P = mf.basic_dof_nodes()
+    U = np.array([field(P[:, i]) for i in range(P.shape[1])])
+    mf.export_to_exodus("check_exodus_comp.exo", U, "u")                 # default
+    mf.export_to_exodus("check_exodus_unc.exo", "uncompressed", U, "u")  # opt out
+    sc = os.path.getsize("check_exodus_comp.exo")
+    su = os.path.getsize("check_exodus_unc.exo")
+    with open("check_exodus_comp.exo", "rb") as f:
+        default_is_hdf5 = f.read(8) == b"\x89HDF\r\n\x1a\n"
+    if default_is_hdf5:
+        check(sc < su, "compression: default file smaller than uncompressed "
+              "(%d vs %d)" % (sc, su))
+    else:
+        check(sc > 0 and su > 0, "compression: default classic file written")
+    # default output must round-trip through GetFEM in either format
+    m2 = gf.Mesh("import", "exodus", "check_exodus_comp.exo")
+    pts = m2.pts()
+    vals = np.asarray(m2.exodus_nodal_data("check_exodus_comp.exo", "u", 0)).ravel()
+    err = max(abs(vals[i] - field(pts[:, i])) for i in range(vals.size))
+    check(err < 1e-10, "compression: compressed file round-trips (err=%g)" % err)
+    try:
+        from scipy.io import netcdf_file
+        netcdf_file("check_exodus_unc.exo", "r", mmap=False).close()
+        ok_unc = True
+    except Exception:
+        ok_unc = False
+    check(ok_unc, "compression: scipy reads the uncompressed file")
+    mode = "NetCDF4 compressed" if default_is_hdf5 else "classic 64-bit offset"
+    print("  compression: default %s %d B vs uncompressed %d B, round-trip err %g"
+          % (mode, sc, su, err))
+
+
+print("Exodus python import/export test")
+for kind in ("tri", "quad", "tet", "hex"):
+    for order in (1, 2):
+        roundtrip(kind, order)
+for kind in ("tri", "quad", "tet", "hex"):
+    region_roundtrip(kind)
+for kind in ("tri", "quad", "tet", "hex"):
+    volume_region_roundtrip(kind)
+streaming_roundtrip()
+independent_reader_check()
+region_names_check()
+streaming_region_check()
+compression_check()
+
+if errors:
+    print("FAILED (%d errors)" % errors)
+else:
+    print("all Exodus python tests passed")
+assert errors == 0

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -116,6 +116,7 @@ nobase_include_HEADERS =                                   \
   getfem/getfem_config.h                                   \
   getfem/getfem_interpolation.h                            \
   getfem/getfem_export.h                                   \
+  getfem/getfem_exodus.h                                   \
   getfem/getfem_import.h                                   \
   getfem/getfem_derivatives.h                              \
   getfem/getfem_global_function.h                          \
@@ -244,11 +245,23 @@ SRC =                                                      \
   getfem_continuation.cc
 #  getfem_enumeration_dof_para.cc
 
+# Exodus II support is optional (configure --enable-exodus). The source is
+# compiled into libgetfem only when enabled, and the NetCDF library is linked
+# only then (@NETCDF_LIBS@ is empty otherwise).
+if EXODUS
+EXODUS_SRC = getfem_exodus.cc
+else
+EXODUS_SRC =
+endif
+
 lib_LTLIBRARIES = libgetfem.la
-libgetfem_la_SOURCES = $(SRC)
+libgetfem_la_SOURCES = $(SRC) $(EXODUS_SRC)
 libgetfem_la_LDFLAGS = ${LIBTOOL_VERSION_INFO}
-libgetfem_la_LIBADD = @SUPERLU_LIBS@ @MUMPS_LIBS@
+libgetfem_la_LIBADD = @SUPERLU_LIBS@ @MUMPS_LIBS@ @NETCDF_LIBS@
 AM_CPPFLAGS = -I$(top_srcdir)/src -I../src -I$(top_srcdir)
+
+# always shipped in the tarball, even when Exodus is disabled
+EXTRA_DIST = getfem_exodus.cc
 
 CLEANFILES = ii_files/* *.o.d getfem/getfem_im_list.h
 DISTCLEANFILES = getfem/getfem_arch_config.h gmm/gmm_arch_config.h

--- a/src/getfem/getfem_arch_config.h.in
+++ b/src/getfem/getfem_arch_config.h.in
@@ -12,6 +12,12 @@
 /* defined if the cxxabi.h header file is available */
 #undef GETFEM_HAVE_CXXABI_H
 
+/* defined if GetFEM is built with Exodus II file support (--enable-exodus) */
+#undef GETFEM_HAVE_EXODUS
+
+/* defined if NetCDF supports NetCDF4/HDF5 deflate for Exodus compression */
+#undef GETFEM_HAVE_EXODUS_NETCDF4
+
 /* glibc floating point exceptions control */
 #undef GETFEM_HAVE_FEENABLEEXCEPT
 

--- a/src/getfem/getfem_exodus.h
+++ b/src/getfem/getfem_exodus.h
@@ -1,0 +1,293 @@
+/* -*- c++ -*- (enables emacs c++ mode) */
+/*===========================================================================
+
+ Copyright (C) 2026 GetFEM contributors
+
+ This file is a part of GetFEM
+
+ GetFEM  is  free software;  you  can  redistribute  it  and/or modify it
+ under  the  terms  of the  GNU  Lesser General Public License as published
+ by  the  Free Software Foundation;  either version 3 of the License,  or
+ (at your option) any later version along with the GCC Runtime Library
+ Exception either version 3.1 or (at your option) any later version.
+ This program  is  distributed  in  the  hope  that it will be useful,  but
+ WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ or  FITNESS  FOR  A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ License and GCC Runtime Library Exception for more details.
+ You  should  have received a copy of the GNU Lesser General Public License
+ along  with  this program. If not, see https://www.gnu.org/licenses/.
+
+ As a special exception, you  may use  this file  as it is a part of a free
+ software  library  without  restriction.  Specifically,  if   other  files
+ instantiate  templates  or  use macros or inline functions from this file,
+ or  you compile this  file  and  link  it  with other files  to produce an
+ executable, this file  does  not  by itself cause the resulting executable
+ to be covered  by the GNU Lesser General Public License.  This   exception
+ does not  however  invalidate  any  other  reasons why the executable file
+ might be covered by the GNU Lesser General Public License.
+
+===========================================================================*/
+
+/**@file getfem_exodus.h
+   @brief Export/import solutions to/from the Exodus II file format.
+
+   Exodus II is the finite-element database format defined by Sandia's SEACAS
+   project. It is a naming convention layered on top of NetCDF, so this
+   implementation writes/reads the documented Exodus entities directly through
+   the NetCDF C API (no dependency on the SEACAS library itself).
+
+   This whole file is only active when GetFEM is configured with
+   --enable-exodus (which defines GETFEM_HAVE_EXODUS and links NetCDF).
+*/
+#ifndef GETFEM_EXODUS_H__
+#define GETFEM_EXODUS_H__
+
+#include "getfem_export.h"
+
+namespace getfem {
+
+#ifdef GETFEM_HAVE_EXODUS
+
+  /** @brief Exodus II export.
+
+      Mirrors the logic of getfem::vtk_export: an internal classical mesh_fem
+      (of order 1 or 2, suitable for Exodus element types) is built from the
+      exported mesh/mesh_fem, fields are interpolated onto it, and only the
+      degrees of freedom that map to Exodus nodes are written.
+
+      A single Exodus file natively stores a transient (time-dependent) series:
+      call set_time() to open a new time step, then write_point_data() for each
+      field at that step. The file is finalised (and the buffered transient data
+      flushed) when close() is called or the object is destroyed.
+  */
+  class exodus_export {
+  protected:
+    std::string fname_;
+    int ncid_;                 // NetCDF file id (valid while file_open_)
+    bool file_open_;
+    char title_[256];
+    int d_num_nodes_, d_time_, d_len_name_; // NetCDF dim ids reused on close()
+
+    std::unique_ptr<mesh_fem> pmf_; // classical export mesh_fem
+    dal::bit_vector pmf_dof_used_;  // basic dofs actually exported as nodes
+    std::vector<int> dofmap_;       // basic dof -> 0-based compacted node index
+    size_type nb_nodes_;
+    dim_type dim_;
+    std::map<int, std::string> region_names_; // region id -> Exodus block/set name
+
+    // One Exodus element block per (volume region, element type). When no
+    // volume region covers a convex it falls in a default block keyed by type.
+    struct block_info {
+      std::string ex_type;            // e.g. "TETRA10"
+      size_type nodes_per_elem;
+      std::vector<unsigned> perm;     // perm[exodus_local] = getfem local dof
+      std::vector<size_type> convexes;// convexes (of pmf_) in this block
+      int region_id;                  // GetFEM volume-region id, or -1 if none
+      int block_id;                   // Exodus block id (eb_prop1); == region_id
+                                      // when possible, else a free positive id
+    };
+    std::vector<block_info> blocks_;
+
+    // Transient streaming: each step's slab is written straight to the open
+    // file. The variable set is discovered from step 0 (buffered), declared
+    // once, then later steps stream with no in-memory history.
+    std::vector<std::string> var_names_;    // scalar nodal variable names (order)
+    std::map<std::string, int> var_id_;     // name -> NetCDF varid (once declared)
+    std::map<std::string, std::vector<scalar_type> > step0_; // step-0 buffer
+    int v_time_;                            // NetCDF varid of time_whole
+    int v_nod_names_, v_elem_names_, v_elem_var_tab_;
+    bool vars_declared_;
+    bool transient_definitions_ready_;
+    bool append_mode_;                      // reopened an existing file to append
+    size_type file_nb_nodes_;               // num_nodes read from a reopened file
+    int append_base_step_;                  // file's last step on append (-1 else)
+    int cur_step_;                          // -1 until first set_time/write
+    scalar_type cur_time_;
+    bool cur_time_valid_, cur_time_written_;
+    std::vector<int> elem_var_id_;          // varid of vals_elem_var1eb{b}, per block
+    std::vector<scalar_type> col_;          // reused gather buffer for one component
+    std::vector<std::string> step_written_; // fields written in the current step
+    bool region_field_;                     // write the "region" element variable?
+    bool compression_;                      // create a compressed NetCDF4 file?
+    bool compression_explicit_;             // user explicitly requested mode?
+    int compression_level_;
+    std::string file_mesh_fingerprint_;     // fingerprint read from append target
+
+    enum { EMPTY, EXPORTING, MESH_WRITTEN } state_;
+
+  public:
+    /** Open `fname` for export. If `append` is true the file is reopened and
+        further time steps are appended to it (it must already contain the mesh
+        written for the same mesh_fem); otherwise it is created. */
+    exodus_export(const std::string &fname, bool append = false);
+    ~exodus_export();
+
+    /** should be called before write_mesh / write_point_data */
+    void exporting(const mesh &m);
+    void exporting(const mesh_fem &mf);
+
+    /** the Exodus database title (truncated to 80 chars by the format) */
+    void set_header(const std::string &s);
+
+    /** give GetFEM region `id` a human-readable name, used as the name of the
+        matching Exodus element block / side set / element set / node set.
+        Call before write_mesh(). */
+    void set_region_name(int id, const std::string &name);
+
+    /** also write a "region" element (cell) variable holding each element's
+        block id, so a viewer can colour regions by a discrete per-cell value.
+        Off by default: it is a time-constant field, so storing it at every
+        transient step would bloat the file. Call before write_mesh(). */
+    void enable_region_field(bool on = true);
+
+    /** Set the deflate level (1..9) of the NetCDF4/CLASSIC_MODEL compression
+        used for newly created files. Compression is ON by default when GetFEM
+        was built with usable NetCDF4/HDF5 deflate support; otherwise files
+        default to classic 64-bit offset. Pass level 0 to force classic output.
+        A positive level requires NetCDF4/HDF5 support. Must be called before
+        the file is created (not on append). */
+    void enable_compression(int level = 1);
+
+    /** Predeclare a nodal variable before write_mesh(), avoiding a later
+        NetCDF redefine. Vector fields use the same component names as
+        write_point_data(): name_x, name_y, name_z or name_0... */
+    void declare_point_data(const std::string &name, size_type qdim = 1);
+
+    /** write the mesh (coordinates + element blocks + connectivity). */
+    void write_mesh();
+
+    /** open a new transient time step at value t. Subsequent write_point_data
+        calls attach to this step. */
+    void set_time(scalar_type t);
+
+    /** append a scalar/vector field defined on mf to the current time step.
+        Vector fields are stored as scalar components name_x, name_y, name_z
+        (or name_0 .. for more than 3 components). NO SPACE ALLOWED in name. */
+    template<class VECT>
+    void write_point_data(const mesh_fem &mf, const VECT &U,
+                          const std::string &name);
+
+    /** flush all complete data written so far. A live reader such as ParaView
+        can reload the file after this call and see completed time steps. */
+    void sync();
+
+    /** finalise and close the file (also done by the destructor). */
+    void close();
+
+    const mesh_fem &get_exported_mesh_fem() const;
+
+  private:
+    void init();
+    void build_export_mesh_fem(const mesh_fem &mf);
+    void compute_blocks();
+    void open_for_append_();          // reopen an existing file to append steps
+    std::string mesh_fingerprint_() const;
+    void append_point_data_names_(const std::string &name, size_type qdim);
+    void define_transient_vars_();    // define time/vars while already in define mode
+    void write_transient_metadata_(); // write var names/tables after enddef
+    void write_step_time_and_region_();
+    void check_current_step_complete_() const;
+    void finish_current_step_(bool do_sync);
+    void deflate_var_(int varid) const;
+    void declare_transient_vars_();   // define time/vars + flush buffered step 0
+    void write_region_slab_(size_type step); // (constant) "region" element var
+    // stream already-interpolated, compacted nodal values (size nb_nodes_*Q)
+    void add_nodal_data_(const std::vector<scalar_type> &V, size_type Q,
+                         const std::string &name);
+  };
+
+  /** @brief Exodus II import / field read-back.
+
+      read_mesh() rebuilds a getfem mesh (and turns Exodus side sets into face
+      regions). The transient nodal variables can then be read back into a
+      classical mesh_fem matching the file (build_mesh_fem + read_nodal_var),
+      which is what makes an export -> import round-trip verifiable.
+  */
+  class exodus_import {
+  protected:
+    int ncid_;
+    bool file_open_;
+    std::vector<std::string> nodal_var_names_;
+    std::vector<scalar_type> times_;
+    std::vector<base_node> node_pts_; // filled by read_mesh(), Exodus node order
+    std::vector<int> node_set_ids_;
+    std::map<int, std::vector<size_type> > node_sets_; // id -> getfem point ids
+
+  public:
+    exodus_import(const std::string &fname);
+    ~exodus_import();
+
+    /** rebuild the mesh from the file. Exodus side sets become GetFEM face
+        regions and element sets become convex regions (both keyed by the set
+        id); node sets are recorded separately (see node_set()), as GetFEM has
+        no native node region. */
+    void read_mesh(mesh &m);
+
+    /** ids of the node sets in the file (valid after read_mesh()). */
+    const std::vector<int> &node_set_ids() const { return node_set_ids_; }
+    /** node ids (== getfem point ids) of node set `id`; empty if absent. */
+    const std::vector<size_type> &node_set(int id) const;
+
+    const std::vector<std::string> &nodal_var_names() const
+    { return nodal_var_names_; }
+    const std::vector<scalar_type> &times() const { return times_; }
+    size_type nb_steps() const { return times_.size(); }
+    /** node coordinates in Exodus node order (valid after read_mesh()); node i
+        here corresponds to value i returned by read_nodal_var(). */
+    const std::vector<base_node> &node_points() const { return node_pts_; }
+
+    /** build a classical mesh_fem on m whose nodes coincide with the Exodus
+        nodes (order chosen so dof i <-> Exodus node i). */
+    void build_mesh_fem(const mesh &m, mesh_fem &mf) const;
+
+    /** read nodal variable `name` at time step `step` (0-based) into U, indexed
+        by Exodus node number (== dof of the mesh_fem built by build_mesh_fem). */
+    template<class VECT>
+    void read_nodal_var(const std::string &name, size_type step, VECT &U) const;
+
+    void close();
+
+  private:
+    void read_nodal_var_(const std::string &name, size_type step,
+                         std::vector<scalar_type> &U) const;
+  };
+
+  /** Hook used by getfem::import_mesh(..., "exodus", ...). */
+  void import_mesh_exodus(const std::string &fname, mesh &m);
+
+  /* --- template implementations --- */
+
+  template<class VECT>
+  void exodus_export::write_point_data(const mesh_fem &mf, const VECT &U,
+                                       const std::string &name) {
+    GMM_ASSERT1(state_ >= EXPORTING, "call exporting() first");
+    size_type Q = (gmm::vect_size(U) / mf.nb_dof()) * mf.get_qdim();
+    GMM_ASSERT1(Q >= 1, "empty data");
+    // interpolate the field onto the export mesh_fem, then compact to the
+    // exported nodes (identical bookkeeping to vtk_export::write_point_data).
+    std::vector<scalar_type> V(pmf_->nb_dof() * Q);
+    if (&mf != pmf_.get()) interpolation(mf, *pmf_, U, V);
+    else gmm::copy(U, V);
+    size_type cnt = 0;
+    for (dal::bv_visitor d(pmf_dof_used_); !d.finished(); ++d, ++cnt) {
+      if (cnt != d)
+        for (size_type q=0; q < Q; ++q) V[cnt*Q + q] = V[d*Q + q];
+    }
+    V.resize(Q*nb_nodes_);
+    add_nodal_data_(V, Q, name);
+  }
+
+  template<class VECT>
+  void exodus_import::read_nodal_var(const std::string &name, size_type step,
+                                     VECT &U) const {
+    std::vector<scalar_type> tmp;
+    read_nodal_var_(name, step, tmp);
+    gmm::resize(U, tmp.size());
+    gmm::copy(tmp, U);
+  }
+
+#endif /* GETFEM_HAVE_EXODUS */
+
+} /* end of namespace getfem */
+
+#endif /* GETFEM_EXODUS_H__ */

--- a/src/getfem_exodus.cc
+++ b/src/getfem_exodus.cc
@@ -1,0 +1,1582 @@
+/*===========================================================================
+
+ Copyright (C) 2026 GetFEM contributors
+
+ This file is a part of GetFEM
+
+ GetFEM  is  free software;  you  can  redistribute  it  and/or modify it
+ under  the  terms  of the  GNU  Lesser General Public License as published
+ by  the  Free Software Foundation;  either version 3 of the License,  or
+ (at your option) any later version along with the GCC Runtime Library
+ Exception either version 3.1 or (at your option) any later version.
+ This program  is  distributed  in  the  hope  that it will be useful,  but
+ WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ or  FITNESS  FOR  A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ License and GCC Runtime Library Exception for more details.
+ You  should  have received a copy of the GNU Lesser General Public License
+ along  with  this program. If not, see https://www.gnu.org/licenses/.
+
+===========================================================================*/
+
+#include "getfem/getfem_exodus.h"
+
+#ifdef GETFEM_HAVE_EXODUS
+
+#include <netcdf.h>
+#include <ctime>
+#include <cstdint>
+#include <iomanip>
+#include <limits>
+
+namespace getfem {
+
+  /* helper that turns a NetCDF status code into a GetFEM exception */
+#define EXNC(call) do { int e_nc_ = (call);                                  \
+    GMM_ASSERT1(e_nc_ == NC_NOERR, "NetCDF/Exodus error: "                    \
+                << nc_strerror(e_nc_)); } while (0)
+
+  /* maximum string length used by Exodus (MAX_STR_LENGTH + 1) */
+  static const size_t EXO_STRLEN = 33;
+  static const size_t EXO_IO_CHUNK = 65536;
+
+  static void fnv_add(uint64_t &h, const void *p, size_t n) {
+    const unsigned char *b = static_cast<const unsigned char *>(p);
+    for (size_t i=0; i < n; ++i) { h ^= uint64_t(b[i]); h *= 1099511628211ULL; }
+  }
+
+  static void fnv_add_int(uint64_t &h, int64_t v) {
+    fnv_add(h, &v, sizeof(v));
+  }
+
+  static void fnv_add_size(uint64_t &h, size_type v) {
+    uint64_t u = uint64_t(v); fnv_add(h, &u, sizeof(u));
+  }
+
+  static void fnv_add_scalar(uint64_t &h, scalar_type x) {
+    double d = double(x); fnv_add(h, &d, sizeof(d));
+  }
+
+  static void fnv_add_string(uint64_t &h, const std::string &s) {
+    fnv_add_size(h, s.size());
+    if (!s.empty()) fnv_add(h, s.data(), s.size());
+  }
+
+  static std::string fnv_hex(uint64_t h) {
+    std::ostringstream s;
+    s << std::hex << std::setw(16) << std::setfill('0') << h;
+    return s.str();
+  }
+
+  static std::string exo_get_att_text(int ncid, int varid,
+                                      const std::string &name) {
+    size_t len = 0;
+    if (nc_inq_attlen(ncid, varid, name.c_str(), &len) != NC_NOERR)
+      return std::string();
+    std::vector<char> buf(len + 1, '\0');
+    EXNC(nc_get_att_text(ncid, varid, name.c_str(), buf.data()));
+    return std::string(buf.data(), len);
+  }
+
+  /* read exactly `n` ints from `varid` into `out`. Using nc_get_vara_int with an
+     explicit count bounds the read to the caller's buffer, so a malformed file
+     whose variable is larger than its declared set/length cannot overflow it
+     (and a too-small variable yields a clean NC_EEDGE error). */
+  static void exo_get_ints(int ncid, int varid, size_t n, int *out) {
+    if (n == 0) return;
+    size_t start = 0, count = n;
+    EXNC(nc_get_vara_int(ncid, varid, &start, &count, out));
+  }
+
+  static bool exo_is_shell_type(const std::string &t) {
+    std::string u;
+    for (char ch : t) u.push_back(char(std::toupper(ch)));
+    return u.compare(0,5,"SHELL") == 0 || u.find("SHELL") != std::string::npos;
+  }
+
+  /* ********************************************************************* */
+  /*  Element-type mapping between GetFEM and Exodus.                      */
+  /*                                                                       */
+  /*  The permutation between GetFEM's local node ordering and Exodus'     */
+  /*  PATRAN ordering is derived by matching reference-element             */
+  /*  coordinates, so the same machinery serves both writing and reading   */
+  /*  and there is no hand-transcribed permutation table to get wrong.     */
+  /* ********************************************************************* */
+
+  enum exo_topo { EXO_BAR, EXO_TRI, EXO_QUAD, EXO_TET, EXO_HEX, EXO_WEDGE };
+
+  static base_node exo_nd(scalar_type x) {
+    base_node p(1); p[0] = x; return p; }
+  static base_node exo_nd(scalar_type x, scalar_type y) {
+    base_node p(2); p[0] = x; p[1] = y; return p; }
+  static base_node exo_nd(scalar_type x, scalar_type y, scalar_type z) {
+    base_node p(3); p[0] = x; p[1] = y; p[2] = z; return p; }
+
+  static base_node exo_mid(const base_node &a, const base_node &b) {
+    base_node r(a);
+    for (size_type i=0; i < a.size(); ++i) r[i] = 0.5*(a[i]+b[i]);
+    return r;
+  }
+  static base_node exo_center(const std::vector<base_node> &c,
+                              std::initializer_list<int> idx) {
+    base_node r(c[0].size()); r.fill(0.);
+    for (int i : idx) for (size_type k=0; k < r.size(); ++k) r[k] += c[i][k];
+    for (size_type k=0; k < r.size(); ++k) r[k] /= scalar_type(idx.size());
+    return r;
+  }
+
+  /* Exodus corner nodes, in Exodus order, in GetFEM's unit reference frame. */
+  static std::vector<base_node> exo_corners(exo_topo topo) {
+    switch (topo) {
+    case EXO_BAR: return { exo_nd(0.), exo_nd(1.) };
+    case EXO_TRI: return { exo_nd(0,0), exo_nd(1,0), exo_nd(0,1) };
+    case EXO_QUAD: return { exo_nd(0,0), exo_nd(1,0), exo_nd(1,1), exo_nd(0,1) };
+    case EXO_TET: return { exo_nd(0,0,0), exo_nd(1,0,0),
+                           exo_nd(0,1,0), exo_nd(0,0,1) };
+    case EXO_HEX: return { exo_nd(0,0,0), exo_nd(1,0,0), exo_nd(1,1,0),
+                           exo_nd(0,1,0), exo_nd(0,0,1), exo_nd(1,0,1),
+                           exo_nd(1,1,1), exo_nd(0,1,1) };
+    case EXO_WEDGE: return { exo_nd(0,0,0), exo_nd(1,0,0), exo_nd(0,1,0),
+                             exo_nd(0,0,1), exo_nd(1,0,1), exo_nd(0,1,1) };
+    }
+    GMM_ASSERT1(false, "internal error");
+  }
+
+  /* Exodus edges (corner-index pairs), in Exodus edge order. */
+  static std::vector<std::pair<int,int> > exo_edges(exo_topo topo) {
+    switch (topo) {
+    case EXO_BAR: return { {0,1} };
+    case EXO_TRI: return { {0,1},{1,2},{2,0} };
+    case EXO_QUAD: return { {0,1},{1,2},{2,3},{3,0} };
+    case EXO_TET: return { {0,1},{1,2},{2,0},{0,3},{1,3},{2,3} };
+    case EXO_HEX: return { {0,1},{1,2},{2,3},{3,0},   // bottom-face edges
+                           {0,4},{1,5},{2,6},{3,7},   // vertical edges
+                           {4,5},{5,6},{6,7},{7,4} }; // top-face edges
+    case EXO_WEDGE: return { {0,1},{1,2},{2,0},   // bottom-triangle edges
+                             {0,3},{1,4},{2,5},   // vertical edges
+                             {3,4},{4,5},{5,3} }; // top-triangle edges
+    }
+    GMM_ASSERT1(false, "internal error");
+  }
+
+  /* Full ordered Exodus reference coordinates for the given topology / node
+     count, in GetFEM's unit reference frame. */
+  static std::vector<base_node> exo_reference(exo_topo topo, size_type nbd) {
+    std::vector<base_node> c = exo_corners(topo);
+    std::vector<base_node> r = c;
+    if (r.size() == nbd) return r;                  // linear element
+    for (const auto &e : exo_edges(topo))           // quadratic edge nodes
+      r.push_back(exo_mid(c[e.first], c[e.second]));
+    if (r.size() == nbd) return r;                  // serendipity (8,15,20)
+    if (topo == EXO_QUAD && nbd == 9) {             // QUAD9 centre
+      r.push_back(exo_center(c, {0,1,2,3})); return r;
+    }
+    if (topo == EXO_HEX && nbd == 27) {  // HEX27: body centre, then 6 face
+      // centres, in the Exodus/PATRAN order verified against libMesh:
+      // body, -z(bottom), +z(top), -x(left), +x(right), -y(front), +y(back).
+      r.push_back(exo_center(c, {0,1,2,3,4,5,6,7})); // body
+      r.push_back(exo_center(c, {0,1,2,3}));         // -z bottom
+      r.push_back(exo_center(c, {4,5,6,7}));         // +z top
+      r.push_back(exo_center(c, {0,3,4,7}));         // -x left
+      r.push_back(exo_center(c, {1,2,5,6}));         // +x right
+      r.push_back(exo_center(c, {0,1,4,5}));         // -y front
+      r.push_back(exo_center(c, {2,3,6,7}));         // +y back
+      return r;
+    }
+    GMM_ASSERT1(false, "unsupported Exodus node count " << nbd
+                << " for this element topology");
+  }
+
+  static std::string exo_typestring(exo_topo topo, size_type nbd) {
+    switch (topo) {
+    case EXO_BAR:   return nbd==2 ? "BAR2" : "BAR3";
+    case EXO_TRI:   return nbd==3 ? "TRI3" : "TRI6";
+    case EXO_QUAD:  return nbd==4 ? "QUAD4" : (nbd==8 ? "QUAD8" : "QUAD9");
+    case EXO_TET:   return nbd==4 ? "TETRA4" : "TETRA10";
+    case EXO_HEX:   return nbd==8 ? "HEX8" : (nbd==20 ? "HEX20" : "HEX27");
+    case EXO_WEDGE: return nbd==6 ? "WEDGE6" : "WEDGE15";
+    }
+    GMM_ASSERT1(false, "internal error");
+  }
+
+  /* classify a convex's linear topology from its (basic) structure */
+  static exo_topo exo_topo_of_structure(bgeot::pconvex_structure cvs) {
+    bgeot::pconvex_structure b = bgeot::basic_structure(cvs);
+    dim_type d = b->dim();
+    short_type nv = b->nb_points();
+    if (d == 1) return EXO_BAR;
+    if (d == 2) { if (nv == 3) return EXO_TRI; if (nv == 4) return EXO_QUAD; }
+    if (d == 3) {
+      if (nv == 4) return EXO_TET;
+      if (nv == 6) return EXO_WEDGE;
+      if (nv == 8) return EXO_HEX;
+    }
+    GMM_ASSERT1(false, "this element (dim " << int(d) << ", " << nv
+                << " vertices) has no Exodus equivalent");
+  }
+
+  /* parse an Exodus element-type string into a topology */
+  static exo_topo exo_topo_of_name(const std::string &t) {
+    std::string u; for (char ch : t) u.push_back(char(std::toupper(ch)));
+    if (u.compare(0,3,"BAR")==0 || u.compare(0,4,"BEAM")==0 ||
+        u.compare(0,5,"TRUSS")==0) return EXO_BAR;
+    if (u.compare(0,5,"TETRA")==0 || u.compare(0,3,"TET")==0) return EXO_TET;
+    if (u.compare(0,3,"HEX")==0) return EXO_HEX;
+    if (u.compare(0,5,"WEDGE")==0 || u.compare(0,5,"PRISM")==0) return EXO_WEDGE;
+    // SHELL* is read as a 2D QUAD surface element. NB: a shell's side numbering
+    // (top/bottom faces + edges) is NOT the 2D quad-edge numbering, so side sets
+    // on shell elements from external files will not be translated correctly.
+    if (u.compare(0,4,"QUAD")==0 || u.compare(0,5,"SHELL")==0) return EXO_QUAD;
+    if (u.compare(0,3,"TRI")==0) return EXO_TRI; // after TETRA/TRUSS
+    GMM_ASSERT1(false, "unsupported Exodus element type '" << t << "'");
+  }
+
+  static bgeot::pgeometric_trans exo_pgt(exo_topo topo, size_type nbd) {
+    switch (topo) {
+    case EXO_BAR:   return bgeot::simplex_geotrans(1, nbd==2 ? 1 : 2);
+    case EXO_TRI:   return bgeot::simplex_geotrans(2, nbd==3 ? 1 : 2);
+    case EXO_QUAD:
+      if (nbd==4) return bgeot::parallelepiped_geotrans(2,1);
+      if (nbd==8) return bgeot::Q2_incomplete_geotrans(2);
+      return bgeot::parallelepiped_geotrans(2,2);
+    case EXO_TET:   return bgeot::simplex_geotrans(3, nbd==4 ? 1 : 2);
+    case EXO_HEX:
+      if (nbd==8)  return bgeot::parallelepiped_geotrans(3,1);
+      if (nbd==20) return bgeot::Q2_incomplete_geotrans(3);
+      return bgeot::parallelepiped_geotrans(3,2);
+    case EXO_WEDGE:
+      if (nbd==6) return bgeot::prism_geotrans(3,1);
+      return bgeot::prism_incomplete_P2_geotrans();
+    }
+    GMM_ASSERT1(false, "internal error");
+  }
+
+  /* perm[exodus_local] = gf_local index, by reference-coordinate matching */
+  static std::vector<unsigned>
+  exo_build_perm(const std::vector<base_node> &gfref,
+                 const std::vector<base_node> &exoref) {
+    GMM_ASSERT1(gfref.size() == exoref.size(),
+                "Exodus node-count mismatch (" << gfref.size() << " vs "
+                << exoref.size() << ")");
+    std::vector<unsigned> perm(exoref.size());
+    std::vector<bool> used(gfref.size(), false);
+    for (size_type e=0; e < exoref.size(); ++e) {
+      size_type best = size_type(-1); scalar_type bd = 1e30;
+      for (size_type g=0; g < gfref.size(); ++g) if (!used[g]) {
+        scalar_type d = gmm::vect_dist2(gfref[g], exoref[e]);
+        if (d < bd) { bd = d; best = g; }
+      }
+      GMM_ASSERT1(best != size_type(-1) && bd < 1e-6,
+                  "could not match GetFEM and Exodus reference nodes");
+      perm[e] = unsigned(best); used[best] = true;
+    }
+    return perm;
+  }
+
+
+  static size_type exo_corner_count(exo_topo topo) {
+    switch (topo) {
+    case EXO_BAR: return 2; case EXO_TRI: return 3; case EXO_QUAD: return 4;
+    case EXO_TET: return 4; case EXO_HEX: return 8; case EXO_WEDGE: return 6;
+    }
+    GMM_ASSERT1(false, "internal error");
+  }
+
+  /* Exodus sides (element faces) as corner-index lists, in Exodus side order. */
+  static std::vector<std::vector<int> > exo_sides(exo_topo topo) {
+    switch (topo) {
+    case EXO_BAR:   return { {0}, {1} };
+    case EXO_TRI:   return { {0,1},{1,2},{2,0} };
+    case EXO_QUAD:  return { {0,1},{1,2},{2,3},{3,0} };
+    case EXO_TET:   return { {0,1,3},{1,2,3},{0,3,2},{0,2,1} };
+    case EXO_HEX:   return { {0,1,5,4},{1,2,6,5},{2,3,7,6},
+                             {0,4,7,3},{0,3,2,1},{4,5,6,7} };
+    case EXO_WEDGE: return { {0,1,4,3},{1,2,5,4},{0,3,5,2},{0,2,1},{3,4,5} };
+    }
+    GMM_ASSERT1(false, "internal error");
+  }
+
+  static base_node exo_centroid(const std::vector<base_node> &pts,
+                                const std::vector<int> &idx) {
+    base_node c(pts[0].size()); c.fill(0.);
+    for (int i : idx) for (size_type k=0; k < c.size(); ++k) c[k] += pts[i][k];
+    for (size_type k=0; k < c.size(); ++k) c[k] /= scalar_type(idx.size());
+    return c;
+  }
+
+  /* face_perm[getfem local face] = Exodus side index, matched by comparing the
+     face centroids on the reference element (same idea as the node mapping, so
+     no hand-maintained face table). */
+  static std::vector<unsigned> exo_face_perm(exo_topo topo) {
+    bgeot::pgeometric_trans lpgt = exo_pgt(topo, exo_corner_count(topo));
+    bgeot::pconvex_structure cvs = lpgt->structure();
+    std::vector<base_node> gc(lpgt->geometric_nodes().begin(),
+                              lpgt->geometric_nodes().end());
+    std::vector<base_node> ec = exo_corners(topo);
+    std::vector<std::vector<int> > sides = exo_sides(topo);
+    short_type nf = cvs->nb_faces();
+    GMM_ASSERT1(size_type(nf) == sides.size(),
+                "Exodus side-count mismatch for this topology");
+    std::vector<unsigned> fperm(nf);
+    for (short_type f=0; f < nf; ++f) {
+      const bgeot::convex_ind_ct &ip = cvs->ind_points_of_face(f);
+      base_node cg = exo_centroid(gc, std::vector<int>(ip.begin(), ip.end()));
+      size_type best = size_type(-1); scalar_type bd = 1e30;
+      for (size_type s=0; s < sides.size(); ++s) {
+        scalar_type d = gmm::vect_dist2(cg, exo_centroid(ec, sides[s]));
+        if (d < bd) { bd = d; best = s; }
+      }
+      GMM_ASSERT1(best != size_type(-1) && bd < 1e-6,
+                  "could not match GetFEM face to Exodus side");
+      fperm[f] = unsigned(best);
+    }
+    return fperm;
+  }
+
+
+  /* ********************************************************************* */
+  /*  Exodus export                                                        */
+  /* ********************************************************************* */
+
+  exodus_export::exodus_export(const std::string &fname, bool append)
+    : fname_(fname), ncid_(-1), file_open_(false) {
+    init();
+    if (append) open_for_append_();
+  }
+
+  exodus_export::~exodus_export() { try { close(); } catch (...) {} }
+
+  void exodus_export::init() {
+    strcpy(title_, "Exported by GetFEM");
+    nb_nodes_ = 0; dim_ = dim_type(-1); cur_step_ = -1; state_ = EMPTY;
+    v_time_ = -1; v_nod_names_ = -1; v_elem_names_ = -1; v_elem_var_tab_ = -1;
+    vars_declared_ = false; transient_definitions_ready_ = false;
+    append_mode_ = false;
+    file_nb_nodes_ = 0; region_field_ = false; append_base_step_ = -1;
+    cur_time_ = scalar_type(0); cur_time_valid_ = false; cur_time_written_ = false;
+    compression_explicit_ = false;
+#ifdef GETFEM_HAVE_EXODUS_NETCDF4
+    compression_ = true;  // compressed NetCDF4 by default when available
+#else
+    compression_ = false; // classic 64-bit offset when NetCDF4 is unavailable
+#endif
+    compression_level_ = 1;
+    file_mesh_fingerprint_.clear();
+  }
+
+  /* Reopen an existing Exodus file to append further time steps: read the node
+     count, the current number of steps and the already-declared transient
+     variables, so set_time/write_point_data continue where the file left off. */
+  void exodus_export::open_for_append_() {
+    EXNC(nc_open(fname_.c_str(), NC_WRITE, &ncid_));
+    file_open_ = true;
+    append_mode_ = true;
+    int d; size_t n = 0;
+    EXNC(nc_inq_dimid(ncid_, "num_nodes", &d));
+    EXNC(nc_inq_dimlen(ncid_, d, &n));
+    file_nb_nodes_ = n; d_num_nodes_ = d;
+    file_mesh_fingerprint_ =
+      exo_get_att_text(ncid_, NC_GLOBAL, "getfem_mesh_fingerprint");
+    EXNC(nc_inq_dimid(ncid_, "time_step", &d_time_));
+    size_t nsteps = 0; nc_inq_dimlen(ncid_, d_time_, &nsteps);
+    cur_step_ = int(nsteps) - 1;
+    append_base_step_ = cur_step_;        // steps up to here belong to the file
+    int dln;
+    if (nc_inq_dimid(ncid_, "len_name", &dln) == NC_NOERR) d_len_name_ = dln;
+    int d_nv;
+    if (nc_inq_dimid(ncid_, "num_nod_var", &d_nv) == NC_NOERR) {
+      size_t nv = 0; EXNC(nc_inq_dimlen(ncid_, d_nv, &nv));
+      int v_names; EXNC(nc_inq_varid(ncid_, "name_nod_var", &v_names));
+      EXNC(nc_inq_varid(ncid_, "time_whole", &v_time_));
+      for (size_t k=0; k < nv; ++k) {
+        std::vector<char> buf(EXO_STRLEN+1, '\0');
+        size_t start[2] = { k, 0 }, count[2] = { 1, EXO_STRLEN };
+        EXNC(nc_get_vara_text(ncid_, v_names, start, count, buf.data()));
+        std::string nm(buf.data());
+        var_names_.push_back(nm);
+        std::ostringstream s; s << "vals_nod_var" << (k+1);
+        int vid; EXNC(nc_inq_varid(ncid_, s.str().c_str(), &vid));
+        var_id_[nm] = vid;
+      }
+      vars_declared_ = true;
+      transient_definitions_ready_ = true;   // already defined in the file
+    }
+    // rediscover the "region" element variable so appended steps keep writing it
+    int d_ev;
+    if (nc_inq_dimid(ncid_, "num_elem_var", &d_ev) == NC_NOERR) {
+      size_t nev = 0; EXNC(nc_inq_dimlen(ncid_, d_ev, &nev));
+      GMM_ASSERT1(nev == 1, "Exodus append: GetFEM only supports appending "
+                  "to files whose sole element variable is 'region'");
+      int v_enames;
+      EXNC(nc_inq_varid(ncid_, "name_elem_var", &v_enames));
+      std::vector<char> buf(EXO_STRLEN+1, '\0');
+      size_t start[2] = { 0, 0 }, count[2] = { 1, EXO_STRLEN };
+      EXNC(nc_get_vara_text(ncid_, v_enames, start, count, buf.data()));
+      GMM_ASSERT1(std::string(buf.data()) == "region",
+                  "Exodus append: existing element variable is not 'region'");
+      int d_blk; EXNC(nc_inq_dimid(ncid_, "num_el_blk", &d_blk));
+      size_t nblk = 0; EXNC(nc_inq_dimlen(ncid_, d_blk, &nblk));
+      elem_var_id_.resize(nblk);
+      for (size_t b=0; b < nblk; ++b) {
+        std::ostringstream sv; sv << "vals_elem_var1eb" << (b+1);
+        EXNC(nc_inq_varid(ncid_, sv.str().c_str(), &elem_var_id_[b]));
+      }
+      // the file already holds (region) transient definitions: mark them ready
+      // so appended steps stream instead of re-entering define mode (which would
+      // collide with the existing variables) -- needed for region-only files
+      region_field_ = true;
+      vars_declared_ = true;
+      transient_definitions_ready_ = true;
+    }
+  }
+
+  void exodus_export::set_header(const std::string &s) {
+    strncpy(title_, s.c_str(), 255); title_[255] = 0;
+  }
+
+  void exodus_export::set_region_name(int id, const std::string &name) {
+    region_names_[id] = name;
+  }
+
+  void exodus_export::enable_region_field(bool on) { region_field_ = on; }
+
+  void exodus_export::enable_compression(int level) {
+    GMM_ASSERT1(state_ < MESH_WRITTEN && !append_mode_,
+                "Exodus compression must be (de)selected before the file is "
+                "created, and cannot be changed on append");
+    if (level > 0) {
+#ifndef GETFEM_HAVE_EXODUS_NETCDF4
+      GMM_ASSERT1(false, "Exodus compression requires NetCDF4/HDF5 deflate "
+                  "support; rebuild GetFEM with such a NetCDF library or pass "
+                  "level 0 / 'uncompressed'");
+#endif
+    }
+    compression_explicit_ = true;
+    compression_ = (level > 0);
+    compression_level_ = std::max(0, std::min(level, 9));
+  }
+
+  void exodus_export::declare_point_data(const std::string &name,
+                                         size_type qdim) {
+    GMM_ASSERT1(!append_mode_, "Exodus append uses the variables already "
+                "declared in the existing file");
+    GMM_ASSERT1(!vars_declared_ && state_ < MESH_WRITTEN,
+                "declare_point_data() must be called before write_mesh()");
+    append_point_data_names_(name, qdim);
+  }
+
+  const mesh_fem &exodus_export::get_exported_mesh_fem() const {
+    GMM_ASSERT1(pmf_.get(), "no mesh_fem to export"); return *pmf_;
+  }
+
+  void exodus_export::exporting(const mesh &m) {
+    dim_ = m.dim();
+    GMM_ASSERT1(dim_ <= 3, "Exodus export: dimension " << int(dim_)
+                << " not supported");
+    pmf_ = std::make_unique<mesh_fem>(const_cast<mesh&>(m), dim_type(1));
+    for (dal::bv_visitor cv(m.convex_index()); !cv.finished(); ++cv) {
+      bgeot::pgeometric_trans pgt = m.trans_of_convex(cv);
+      pfem pf = classical_fem(pgt, pgt->complexity() > 1 ? 2 : 1);
+      pmf_->set_finite_element(cv, pf);
+    }
+    exporting(*pmf_);
+  }
+
+  void exodus_export::exporting(const mesh_fem &mf) {
+    dim_ = mf.linked_mesh().dim();
+    GMM_ASSERT1(dim_ <= 3, "Exodus export: dimension " << int(dim_)
+                << " not supported");
+    build_export_mesh_fem(mf);
+    compute_blocks();
+    if (append_mode_) {
+      GMM_ASSERT1(nb_nodes_ == file_nb_nodes_, "Exodus append: the mesh_fem "
+                  "yields " << nb_nodes_ << " export nodes but the existing file "
+                  "has " << file_nb_nodes_ << " (must be the same mesh_fem)");
+      GMM_ASSERT1(!file_mesh_fingerprint_.empty(),
+                  "Exodus append: existing file has no GetFEM mesh "
+                  "fingerprint; unsafe append is refused");
+      std::string fp = mesh_fingerprint_();
+      GMM_ASSERT1(fp == file_mesh_fingerprint_,
+                  "Exodus append: mesh/block/connectivity fingerprint mismatch; "
+                  "append requires the same exported mesh that created the file");
+      state_ = MESH_WRITTEN;   // mesh is already in the file; do not rewrite it
+    } else
+      state_ = EXPORTING;
+  }
+
+  /* Build an export mesh_fem of classical (order 1 or 2) elements suitable for
+     Exodus. This mirrors vtk_export::exporting(const mesh_fem&). */
+  void exodus_export::build_export_mesh_fem(const mesh_fem &mf) {
+    if (&mf != pmf_.get())
+      pmf_ = std::make_unique<mesh_fem>(mf.linked_mesh());
+    for (dal::bv_visitor cv(mf.convex_index()); !cv.finished(); ++cv) {
+      bgeot::pgeometric_trans pgt = mf.linked_mesh().trans_of_convex(cv);
+      pfem pf = mf.fem_of_element(cv);
+      if (pf == fem_descriptor("FEM_Q2_INCOMPLETE(2)") ||
+          pf == fem_descriptor("FEM_Q2_INCOMPLETE(3)") ||
+          pf == fem_descriptor("FEM_PRISM_INCOMPLETE_P2") ||
+          pf == fem_descriptor("FEM_PRISM_INCOMPLETE_P2_DISCONTINUOUS"))
+        pmf_->set_finite_element(cv, pf);
+      else {
+        bool discontinuous = false;
+        for (unsigned i=0; i < pf->nb_dof(cv); ++i)
+          if (!dof_linkable(pf->dof_types()[i])) { discontinuous = true; break; }
+        pfem classical_pf1 = discontinuous ? classical_discontinuous_fem(pgt, 1)
+                                           : classical_fem(pgt, 1);
+        short_type degree = 1;
+        if ((pf != classical_pf1 && pf->estimated_degree() > 1) ||
+            pgt->structure() != pgt->basic_structure())
+          degree = 2;
+        pmf_->set_finite_element(cv, discontinuous ?
+                                 classical_discontinuous_fem(pgt, degree, 0, true) :
+                                 classical_fem(pgt, degree, true));
+      }
+    }
+  }
+
+  /* Determine, per convex, the Exodus block it belongs to (one block per
+     element type), the GetFEM->Exodus node permutation, and the set of dofs
+     actually written as Exodus nodes. */
+  void exodus_export::compute_blocks() {
+    const mesh &m = pmf_->linked_mesh();
+    blocks_.clear();
+    pmf_dof_used_.sup(0, pmf_->nb_basic_dof());
+
+    /* A convex's "primary" volume region = the smallest-id region that contains
+       it as a whole convex (face entries -> side sets, never blocks). When such
+       regions exist each one becomes its own Exodus block, so tools like
+       ParaView show/colour the regions natively (by block / ObjectId); convexes
+       in no volume region fall in a default block keyed by element type. Element
+       sets are still written too, so the GetFEM region round-trip is unchanged. */
+    // indexed by convex id (contiguous): -1 = convex in no volume region
+    std::vector<int> primary_region(m.convex_index().last_true() + 1, -1);
+    for (dal::bv_visitor r(m.regions_index()); !r.finished(); ++r)
+      for (getfem::mr_visitor i(m.region(r)); !i.finished(); ++i) {
+        if (i.is_face()) continue;
+        int &pr = primary_region[i.cv()];
+        if (pr < 0 || int(r) < pr) pr = int(r);
+      }
+
+    std::map<std::pair<int, std::string>, size_type> block_of_key;
+    for (dal::bv_visitor cv(pmf_->convex_index()); !cv.finished(); ++cv) {
+      pfem pf = pmf_->fem_of_element(cv);
+      size_type nbd = pf->nb_dof(cv);
+      exo_topo topo = exo_topo_of_structure(m.structure_of_convex(cv));
+      std::string et = exo_typestring(topo, nbd);
+      int rid = primary_region[cv];          // -1 when in no volume region
+
+      size_type bi;
+      std::pair<int, std::string> key(rid, et);
+      auto it = block_of_key.find(key);
+      if (it == block_of_key.end()) {
+        bi = blocks_.size();
+        block_of_key[key] = bi;
+        block_info b;
+        b.ex_type = et;
+        b.nodes_per_elem = nbd;
+        b.region_id = rid;
+        b.block_id = -1;              // assigned below
+        // build the permutation once per block from this convex's reference dofs
+        std::vector<base_node> gfref(nbd);
+        for (size_type i=0; i < nbd; ++i) gfref[i] = pf->node_of_dof(cv, i);
+        b.perm = exo_build_perm(gfref, exo_reference(topo, nbd));
+        blocks_.push_back(b);
+      } else bi = it->second;
+
+      blocks_[bi].convexes.push_back(cv);
+      for (size_type i=0; i < nbd; ++i)
+        pmf_dof_used_.add(pmf_->ind_basic_dof_of_element(cv)[i]);
+    }
+
+    /* Exodus block ids: a region-based block claims its region id (so ParaView's
+       ObjectId equals the GetFEM region id); any extra block -- a second element
+       type within the same region, or a non-region block -- gets the next free
+       positive id not already claimed by a region. */
+    std::set<int> used;
+    for (const auto &b : blocks_) if (b.region_id >= 0) used.insert(b.region_id);
+    std::set<int> region_taken;
+    int nextfree = 1;
+    for (auto &b : blocks_) {
+      if (b.region_id >= 0 && !region_taken.count(b.region_id)) {
+        b.block_id = b.region_id;
+        region_taken.insert(b.region_id);
+      } else {
+        while (used.count(nextfree)) ++nextfree;
+        b.block_id = nextfree;
+        used.insert(nextfree);
+      }
+    }
+
+    // compact the used dofs to a 0-based contiguous node numbering
+    dofmap_.assign(pmf_->nb_basic_dof(), -1);
+    int cnt = 0;
+    for (dal::bv_visitor d(pmf_dof_used_); !d.finished(); ++d) dofmap_[d] = cnt++;
+    nb_nodes_ = size_type(cnt);
+  }
+
+  std::string exodus_export::mesh_fingerprint_() const {
+    uint64_t h = 1469598103934665603ULL;
+    fnv_add_string(h, "getfem-exodus-mesh-v1");
+    fnv_add_int(h, int64_t(dim_));
+    fnv_add_size(h, nb_nodes_);
+    fnv_add_size(h, blocks_.size());
+    for (dal::bv_visitor d(pmf_dof_used_); !d.finished(); ++d) {
+      base_node P = pmf_->point_of_basic_dof(d);
+      for (size_type k=0; k < size_type(dim_); ++k) fnv_add_scalar(h, P[k]);
+    }
+    for (size_type b=0; b < blocks_.size(); ++b) {
+      const block_info &bk = blocks_[b];
+      fnv_add_int(h, bk.block_id);
+      fnv_add_int(h, bk.region_id);
+      fnv_add_string(h, bk.ex_type);
+      fnv_add_size(h, bk.nodes_per_elem);
+      fnv_add_size(h, bk.convexes.size());
+      for (size_type cv : bk.convexes) {
+        fnv_add_size(h, cv);
+        auto ind = pmf_->ind_basic_dof_of_element(cv);
+        for (size_type e=0; e < bk.nodes_per_elem; ++e)
+          fnv_add_int(h, dofmap_[ind[bk.perm[e]]] + 1);
+      }
+    }
+    return std::string("getfem-exodus-mesh-v1:") + fnv_hex(h);
+  }
+
+  void exodus_export::deflate_var_(int varid) const {
+#ifndef GETFEM_HAVE_EXODUS_NETCDF4
+    (void)varid;
+#endif
+    if (!compression_) return;
+#ifdef GETFEM_HAVE_EXODUS_NETCDF4
+    EXNC(nc_def_var_deflate(ncid_, varid, 1, 1, compression_level_));
+#else
+    GMM_ASSERT1(false, "Exodus compression requires NetCDF4/HDF5 deflate "
+                "support");
+#endif
+  }
+
+  /* write a fixed-length, NUL-padded string at row `row` of a (n, len) char var */
+  static void exo_put_string(int ncid, int varid, size_t row, size_t len,
+                             const std::string &s) {
+    std::vector<char> buf(len, '\0');
+    for (size_t i=0; i < len-1 && i < s.size(); ++i) buf[i] = s[i];
+    size_t start[2] = { row, 0 }, count[2] = { 1, len };
+    EXNC(nc_put_vara_text(ncid, varid, start, count, buf.data()));
+  }
+
+  void exodus_export::write_mesh() {
+    GMM_ASSERT1(state_ >= EXPORTING, "call exporting() first");
+    if (state_ >= MESH_WRITTEN) return;
+
+    size_type nb_elem = 0;
+    for (const auto &b : blocks_) nb_elem += b.convexes.size();
+    GMM_ASSERT1(nb_nodes_ > 0 && nb_elem > 0, "nothing to export");
+
+    /* Assign 1-based global Exodus element ids in block order and collect side
+       sets from the GetFEM face regions (a region's face entries -> a side
+       set; whole-convex region entries have no Exodus equivalent and are
+       skipped). */
+    const mesh &m = pmf_->linked_mesh();
+    // indexed by convex id (contiguous): 0 = convex not exported as an element
+    std::vector<int> cv_to_elem(m.convex_index().last_true() + 1, 0);
+    { int gid = 0;
+      for (const auto &b : blocks_)
+        for (size_type cv : b.convexes) cv_to_elem[cv] = ++gid; }
+
+    /* Each GetFEM region maps (by its id) to: a side set (its face entries),
+       an element set (its whole-convex entries), and a node set (all nodes it
+       touches). Side/element sets round-trip back to face/convex regions;
+       node sets are extra (useful for nodal BCs) and read back via node_set(). */
+    std::map<exo_topo, std::vector<unsigned> > fperm_cache;
+    std::vector<int> ss_ids, es_ids, ns_ids;
+    std::vector<std::vector<int> > ss_elem, ss_side, es_elem, ns_node;
+    for (dal::bv_visitor r(m.regions_index()); !r.finished(); ++r) {
+      std::vector<int> sel, ssd, eel;
+      std::set<int> nds;
+      for (getfem::mr_visitor i(m.region(r)); !i.finished(); ++i) {
+        int eid = cv_to_elem[i.cv()];
+        if (eid == 0) continue;             // convex not exported as an element
+        if (i.is_face()) {
+          exo_topo topo = exo_topo_of_structure(m.structure_of_convex(i.cv()));
+          auto fit = fperm_cache.find(topo);
+          if (fit == fperm_cache.end())
+            fit = fperm_cache.emplace(topo, exo_face_perm(topo)).first;
+          sel.push_back(eid);
+          ssd.push_back(int(fit->second[i.f()]) + 1);
+          auto fd = pmf_->ind_basic_dof_of_face_of_element(i.cv(), i.f());
+          for (size_type j=0; j < fd.size(); ++j) nds.insert(dofmap_[fd[j]] + 1);
+        } else {
+          eel.push_back(eid);
+          auto cd = pmf_->ind_basic_dof_of_element(i.cv());
+          for (size_type j=0; j < cd.size(); ++j) nds.insert(dofmap_[cd[j]] + 1);
+        }
+      }
+      if (!sel.empty()) {
+        ss_ids.push_back(int(r)); ss_elem.push_back(sel); ss_side.push_back(ssd); }
+      if (!eel.empty()) { es_ids.push_back(int(r)); es_elem.push_back(eel); }
+      if (!nds.empty()) {
+        ns_ids.push_back(int(r));
+        ns_node.push_back(std::vector<int>(nds.begin(), nds.end())); }
+    }
+    size_type n_ss = ss_ids.size(), n_es = es_ids.size(), n_ns = ns_ids.size();
+    std::vector<int> v_ss_elem(n_ss, -1), v_ss_side(n_ss, -1);
+    std::vector<int> v_es_elem(n_es, -1), v_ns_node(n_ns, -1);
+    int v_ssp = -1, v_sss = -1, v_esp = -1, v_ess = -1, v_nsp = -1, v_nss = -1;
+    int v_ssn = -1, v_esn = -1, v_nsn = -1;   // side/elem/node-set name char vars
+
+    int cmode = NC_CLOBBER | NC_64BIT_OFFSET;
+    int e_create = NC_NOERR;
+    if (compression_) {
+#ifdef GETFEM_HAVE_EXODUS_NETCDF4
+      cmode = NC_CLOBBER | NC_NETCDF4 | NC_CLASSIC_MODEL;
+      e_create = nc_create(fname_.c_str(), cmode, &ncid_);
+      if (e_create != NC_NOERR && !compression_explicit_) {
+        compression_ = false;
+        cmode = NC_CLOBBER | NC_64BIT_OFFSET;
+        e_create = nc_create(fname_.c_str(), cmode, &ncid_);
+      }
+#else
+      compression_ = false;
+      e_create = nc_create(fname_.c_str(), cmode, &ncid_);
+#endif
+    } else {
+      e_create = nc_create(fname_.c_str(), cmode, &ncid_);
+    }
+    GMM_ASSERT1(e_create == NC_NOERR, "NetCDF/Exodus error: "
+                << nc_strerror(e_create));
+    file_open_ = true;
+
+    /* --- dimensions --- */
+    int d_dim, d_nodes, d_elem, d_blk, d_str, d_name, d_four, d_time, d_qa;
+    EXNC(nc_def_dim(ncid_, "num_dim",    size_t(dim_),  &d_dim));
+    EXNC(nc_def_dim(ncid_, "num_nodes",  nb_nodes_,     &d_nodes));
+    EXNC(nc_def_dim(ncid_, "num_elem",   nb_elem,       &d_elem));
+    EXNC(nc_def_dim(ncid_, "num_el_blk", blocks_.size(),&d_blk));
+    EXNC(nc_def_dim(ncid_, "len_string", EXO_STRLEN,    &d_str));
+    EXNC(nc_def_dim(ncid_, "len_name",   EXO_STRLEN,    &d_name));
+    EXNC(nc_def_dim(ncid_, "four",       4,             &d_four));
+    EXNC(nc_def_dim(ncid_, "num_qa_rec", 1,             &d_qa));
+    EXNC(nc_def_dim(ncid_, "time_step",  NC_UNLIMITED,  &d_time));
+    d_num_nodes_ = d_nodes; d_time_ = d_time; d_len_name_ = d_name;
+
+    /* --- global attributes --- */
+    float api = 8.03f, ver = 8.03f;
+    int   fpws = int(sizeof(scalar_type)), fsz = 1, i64 = 0;
+    EXNC(nc_put_att_float(ncid_, NC_GLOBAL, "api_version", NC_FLOAT, 1, &api));
+    EXNC(nc_put_att_float(ncid_, NC_GLOBAL, "version",     NC_FLOAT, 1, &ver));
+    EXNC(nc_put_att_int(ncid_, NC_GLOBAL, "floating_point_word_size",
+                        NC_INT, 1, &fpws));
+    EXNC(nc_put_att_int(ncid_, NC_GLOBAL, "file_size",    NC_INT, 1, &fsz));
+    EXNC(nc_put_att_int(ncid_, NC_GLOBAL, "int64_status", NC_INT, 1, &i64));
+    EXNC(nc_put_att_text(ncid_, NC_GLOBAL, "title",
+                         strlen(title_), title_));
+    { std::string fp = mesh_fingerprint_();
+      EXNC(nc_put_att_text(ncid_, NC_GLOBAL, "getfem_mesh_fingerprint",
+                           fp.size(), fp.c_str())); }
+    { const char writer[] = "GetFEM direct NetCDF Exodus writer";
+      EXNC(nc_put_att_text(ncid_, NC_GLOBAL, "getfem_exodus_writer",
+                           strlen(writer), writer)); }
+
+    /* --- coordinate, block and connectivity variables --- */
+    int v_x=-1, v_y=-1, v_z=-1, v_cn, v_ebp, v_ebs, v_ebn, v_qa;
+    EXNC(nc_def_var(ncid_, "coordx", NC_DOUBLE, 1, &d_nodes, &v_x));
+    deflate_var_(v_x);
+    if (dim_ >= 2) { EXNC(nc_def_var(ncid_, "coordy", NC_DOUBLE, 1, &d_nodes, &v_y));
+      deflate_var_(v_y); }
+    if (dim_ >= 3) { EXNC(nc_def_var(ncid_, "coordz", NC_DOUBLE, 1, &d_nodes, &v_z));
+      deflate_var_(v_z); }
+    { int dd[2] = { d_dim, d_str };
+      EXNC(nc_def_var(ncid_, "coor_names", NC_CHAR, 2, dd, &v_cn)); }
+
+    EXNC(nc_def_var(ncid_, "eb_prop1", NC_INT, 1, &d_blk, &v_ebp));
+    deflate_var_(v_ebp);
+    EXNC(nc_put_att_text(ncid_, v_ebp, "name", 2, "ID"));
+    EXNC(nc_def_var(ncid_, "eb_status", NC_INT, 1, &d_blk, &v_ebs));
+    deflate_var_(v_ebs);
+    { int dd[2] = { d_blk, d_name };
+      EXNC(nc_def_var(ncid_, "eb_names", NC_CHAR, 2, dd, &v_ebn)); }
+    { int dd[3] = { d_qa, d_four, d_str };
+      EXNC(nc_def_var(ncid_, "qa_records", NC_CHAR, 3, dd, &v_qa)); }
+
+    std::vector<int> v_connect(blocks_.size());
+    for (size_type b=0; b < blocks_.size(); ++b) {
+      std::ostringstream sd1, sd2;
+      sd1 << "num_el_in_blk" << (b+1); sd2 << "num_nod_per_el" << (b+1);
+      int de, dn;
+      EXNC(nc_def_dim(ncid_, sd1.str().c_str(), blocks_[b].convexes.size(), &de));
+      EXNC(nc_def_dim(ncid_, sd2.str().c_str(), blocks_[b].nodes_per_elem, &dn));
+      std::ostringstream sc; sc << "connect" << (b+1);
+      int dd[2] = { de, dn };
+      EXNC(nc_def_var(ncid_, sc.str().c_str(), NC_INT, 2, dd, &v_connect[b]));
+      deflate_var_(v_connect[b]);
+      EXNC(nc_put_att_text(ncid_, v_connect[b], "elem_type",
+                           blocks_[b].ex_type.size(), blocks_[b].ex_type.c_str()));
+    }
+
+    // identity 1-based id maps (ParaView GlobalElementId / GlobalNodeId)
+    int v_emap, v_nmap;
+    EXNC(nc_def_var(ncid_, "elem_num_map", NC_INT, 1, &d_elem,  &v_emap));
+    deflate_var_(v_emap);
+    EXNC(nc_def_var(ncid_, "node_num_map", NC_INT, 1, &d_nodes, &v_nmap));
+    deflate_var_(v_nmap);
+
+    if (n_ss > 0) {
+      int d_nss;
+      EXNC(nc_def_dim(ncid_, "num_side_sets", n_ss, &d_nss));
+      EXNC(nc_def_var(ncid_, "ss_prop1", NC_INT, 1, &d_nss, &v_ssp));
+      deflate_var_(v_ssp);
+      EXNC(nc_put_att_text(ncid_, v_ssp, "name", 2, "ID"));
+      EXNC(nc_def_var(ncid_, "ss_status", NC_INT, 1, &d_nss, &v_sss));
+      deflate_var_(v_sss);
+      { int dd[2] = { d_nss, d_name };
+        EXNC(nc_def_var(ncid_, "ss_names", NC_CHAR, 2, dd, &v_ssn)); }
+      for (size_type i=0; i < n_ss; ++i) {
+        std::ostringstream sd; sd << "num_side_ss" << (i+1);
+        int dss;
+        EXNC(nc_def_dim(ncid_, sd.str().c_str(), ss_elem[i].size(), &dss));
+        std::ostringstream se, sf;
+        se << "elem_ss" << (i+1); sf << "side_ss" << (i+1);
+        EXNC(nc_def_var(ncid_, se.str().c_str(), NC_INT, 1, &dss, &v_ss_elem[i]));
+        deflate_var_(v_ss_elem[i]);
+        EXNC(nc_def_var(ncid_, sf.str().c_str(), NC_INT, 1, &dss, &v_ss_side[i]));
+        deflate_var_(v_ss_side[i]);
+      }
+    }
+
+    if (n_es > 0) {
+      int d_nes;
+      EXNC(nc_def_dim(ncid_, "num_elem_sets", n_es, &d_nes));
+      EXNC(nc_def_var(ncid_, "els_prop1", NC_INT, 1, &d_nes, &v_esp));
+      deflate_var_(v_esp);
+      EXNC(nc_put_att_text(ncid_, v_esp, "name", 2, "ID"));
+      EXNC(nc_def_var(ncid_, "els_status", NC_INT, 1, &d_nes, &v_ess));
+      deflate_var_(v_ess);
+      { int dd[2] = { d_nes, d_name };
+        EXNC(nc_def_var(ncid_, "els_names", NC_CHAR, 2, dd, &v_esn)); }
+      for (size_type i=0; i < n_es; ++i) {
+        std::ostringstream sd; sd << "num_ele_els" << (i+1);
+        int des;
+        EXNC(nc_def_dim(ncid_, sd.str().c_str(), es_elem[i].size(), &des));
+        std::ostringstream se; se << "elem_els" << (i+1);
+        EXNC(nc_def_var(ncid_, se.str().c_str(), NC_INT, 1, &des, &v_es_elem[i]));
+        deflate_var_(v_es_elem[i]);
+      }
+    }
+
+    if (n_ns > 0) {
+      int d_nns;
+      EXNC(nc_def_dim(ncid_, "num_node_sets", n_ns, &d_nns));
+      EXNC(nc_def_var(ncid_, "ns_prop1", NC_INT, 1, &d_nns, &v_nsp));
+      deflate_var_(v_nsp);
+      EXNC(nc_put_att_text(ncid_, v_nsp, "name", 2, "ID"));
+      EXNC(nc_def_var(ncid_, "ns_status", NC_INT, 1, &d_nns, &v_nss));
+      deflate_var_(v_nss);
+      { int dd[2] = { d_nns, d_name };
+        EXNC(nc_def_var(ncid_, "ns_names", NC_CHAR, 2, dd, &v_nsn)); }
+      for (size_type i=0; i < n_ns; ++i) {
+        std::ostringstream sd; sd << "num_nod_ns" << (i+1);
+        int dns;
+        EXNC(nc_def_dim(ncid_, sd.str().c_str(), ns_node[i].size(), &dns));
+        std::ostringstream sn; sn << "node_ns" << (i+1);
+        EXNC(nc_def_var(ncid_, sn.str().c_str(), NC_INT, 1, &dns, &v_ns_node[i]));
+        deflate_var_(v_ns_node[i]);
+      }
+    }
+    bool predeclared_transient = !var_names_.empty();
+    if (predeclared_transient) define_transient_vars_();
+    EXNC(nc_enddef(ncid_));
+    if (predeclared_transient) {
+      write_transient_metadata_();
+      vars_declared_ = true;
+    }
+
+    /* --- coordinate data (gathered over the compacted nodes) --- */
+    std::vector<double> X(nb_nodes_,0.), Y(nb_nodes_,0.), Z(nb_nodes_,0.);
+    for (dal::bv_visitor d(pmf_dof_used_); !d.finished(); ++d) {
+      base_node P = pmf_->point_of_basic_dof(d);
+      int i = dofmap_[d];
+      X[i] = P[0];
+      if (dim_ >= 2) Y[i] = P[1];
+      if (dim_ >= 3) Z[i] = P[2];
+    }
+    EXNC(nc_put_var_double(ncid_, v_x, X.data()));
+    if (dim_ >= 2) EXNC(nc_put_var_double(ncid_, v_y, Y.data()));
+    if (dim_ >= 3) EXNC(nc_put_var_double(ncid_, v_z, Z.data()));
+    { const char *cn[3] = { "x", "y", "z" };
+      for (size_type k=0; k < size_type(dim_); ++k)
+        exo_put_string(ncid_, v_cn, k, EXO_STRLEN, cn[k]); }
+
+    /* --- block ids / status / names --- */
+    std::vector<int> ebp(blocks_.size()), ebs(blocks_.size(), 1);
+    for (size_type b=0; b < blocks_.size(); ++b) ebp[b] = blocks_[b].block_id;
+    EXNC(nc_put_var_int(ncid_, v_ebp, ebp.data()));
+    EXNC(nc_put_var_int(ncid_, v_ebs, ebs.data()));
+    for (size_type b=0; b < blocks_.size(); ++b) {
+      // a named region uses its name; an unnamed region block -> "region_<id>";
+      // a non-region block keeps the element-type name.
+      std::string bname = blocks_[b].ex_type;
+      if (blocks_[b].region_id >= 0) {
+        auto it = region_names_.find(blocks_[b].region_id);
+        if (it != region_names_.end() && !it->second.empty()) bname = it->second;
+        else { std::ostringstream nm; nm << "region_" << blocks_[b].region_id;
+               bname = nm.str(); }
+      }
+      exo_put_string(ncid_, v_ebn, b, EXO_STRLEN, bname);
+    }
+
+    /* --- one QA record --- */
+    char date[16] = "00000000", tim[16] = "000000";
+    std::time_t tt = std::time(nullptr);
+    if (tt != std::time_t(-1)) {
+      std::tm *lt = std::localtime(&tt);
+      if (lt) { std::strftime(date, sizeof date, "%Y/%m/%d", lt);
+                std::strftime(tim, sizeof tim, "%H:%M:%S", lt); }
+    }
+    { const char *qa[4] = { "GetFEM", "exodus", date, tim };
+      size_t st[3], ct[3] = { 1, 1, EXO_STRLEN };
+      for (int j=0; j < 4; ++j) {
+        std::vector<char> buf(EXO_STRLEN, '\0');
+        for (size_t i=0; i+1 < EXO_STRLEN && i < strlen(qa[j]); ++i)
+          buf[i] = qa[j][i];
+        st[0] = 0; st[1] = size_t(j); st[2] = 0;
+        EXNC(nc_put_vara_text(ncid_, v_qa, st, ct, buf.data()));
+      } }
+
+    /* --- connectivity (1-based, Exodus node ordering) --- */
+    for (size_type b=0; b < blocks_.size(); ++b) {
+      const block_info &bk = blocks_[b];
+      size_type chunk_elems =
+        std::max<size_type>(1, EXO_IO_CHUNK / std::max<size_type>(1, bk.nodes_per_elem));
+      std::vector<int> conn(chunk_elems * bk.nodes_per_elem);
+      for (size_type first=0; first < bk.convexes.size(); first += chunk_elems) {
+        size_type ne = std::min(chunk_elems, bk.convexes.size() - first);
+        size_type p = 0;
+        for (size_type j=0; j < ne; ++j) {
+          size_type cv = bk.convexes[first + j];
+          auto ind = pmf_->ind_basic_dof_of_element(cv);
+          for (size_type e=0; e < bk.nodes_per_elem; ++e)
+            conn[p++] = dofmap_[ind[bk.perm[e]]] + 1;
+        }
+        size_t start[2] = { first, 0 }, count[2] = { ne, bk.nodes_per_elem };
+        EXNC(nc_put_vara_int(ncid_, v_connect[b], start, count, conn.data()));
+      }
+    }
+
+    /* --- identity element/node number maps --- */
+    { std::vector<int> emap(nb_elem);
+      for (size_type i=0; i < nb_elem; ++i) emap[i] = int(i) + 1;
+      EXNC(nc_put_var_int(ncid_, v_emap, emap.data())); }
+    { std::vector<int> nmap(nb_nodes_);
+      for (size_type i=0; i < nb_nodes_; ++i) nmap[i] = int(i) + 1;
+      EXNC(nc_put_var_int(ncid_, v_nmap, nmap.data())); }
+
+    /* --- side sets --- */
+    if (n_ss > 0) {
+      EXNC(nc_put_var_int(ncid_, v_ssp, ss_ids.data()));
+      std::vector<int> sstat(n_ss, 1);
+      EXNC(nc_put_var_int(ncid_, v_sss, sstat.data()));
+      for (size_type i=0; i < n_ss; ++i) {
+        EXNC(nc_put_var_int(ncid_, v_ss_elem[i], ss_elem[i].data()));
+        EXNC(nc_put_var_int(ncid_, v_ss_side[i], ss_side[i].data()));
+      }
+      for (size_type i=0; i < n_ss; ++i) {  // optional set names (empty if unset)
+        auto it = region_names_.find(ss_ids[i]);
+        exo_put_string(ncid_, v_ssn, i, EXO_STRLEN,
+                       it == region_names_.end() ? std::string() : it->second);
+      }
+    }
+
+    /* --- element sets (from whole-convex region entries) --- */
+    if (n_es > 0) {
+      EXNC(nc_put_var_int(ncid_, v_esp, es_ids.data()));
+      std::vector<int> estat(n_es, 1);
+      EXNC(nc_put_var_int(ncid_, v_ess, estat.data()));
+      for (size_type i=0; i < n_es; ++i)
+        EXNC(nc_put_var_int(ncid_, v_es_elem[i], es_elem[i].data()));
+      for (size_type i=0; i < n_es; ++i) {  // optional set names (empty if unset)
+        auto it = region_names_.find(es_ids[i]);
+        exo_put_string(ncid_, v_esn, i, EXO_STRLEN,
+                       it == region_names_.end() ? std::string() : it->second);
+      }
+    }
+
+    /* --- node sets (nodes touched by each region) --- */
+    if (n_ns > 0) {
+      EXNC(nc_put_var_int(ncid_, v_nsp, ns_ids.data()));
+      std::vector<int> nstat(n_ns, 1);
+      EXNC(nc_put_var_int(ncid_, v_nss, nstat.data()));
+      for (size_type i=0; i < n_ns; ++i)
+        EXNC(nc_put_var_int(ncid_, v_ns_node[i], ns_node[i].data()));
+      for (size_type i=0; i < n_ns; ++i) {  // optional set names (empty if unset)
+        auto it = region_names_.find(ns_ids[i]);
+        exo_put_string(ncid_, v_nsn, i, EXO_STRLEN,
+                       it == region_names_.end() ? std::string() : it->second);
+      }
+    }
+
+    state_ = MESH_WRITTEN;
+  }
+
+  static std::string exo_comp_name(const std::string &name, size_type q,
+                                   size_type Q) {
+    if (Q == 1) return name;
+    static const char *xyz[3] = { "x", "y", "z" };
+    std::ostringstream s; s << name << "_";
+    if (Q <= 3) s << xyz[q]; else s << q;
+    return s.str();
+  }
+
+  void exodus_export::append_point_data_names_(const std::string &name,
+                                               size_type Q) {
+    GMM_ASSERT1(Q >= 1, "empty data");
+    for (size_type q=0; q < Q; ++q) {
+      std::string nm = remove_spaces(exo_comp_name(name, q, Q));
+      if (nm.size() >= EXO_STRLEN) nm.resize(EXO_STRLEN - 1);
+      bool seen = false;
+      for (const auto &n : var_names_) if (n == nm) { seen = true; break; }
+      GMM_ASSERT1(!seen, "Exodus transient export: duplicate variable name '"
+                  << nm << "'");
+      var_names_.push_back(nm);
+    }
+  }
+
+  void exodus_export::set_time(scalar_type t) {
+    if (state_ < MESH_WRITTEN) write_mesh();
+    finish_current_step_(true);
+    step_written_.clear();
+    ++cur_step_;                          // continues from the file's last step
+    cur_time_ = t;
+    cur_time_valid_ = true;
+    cur_time_written_ = false;
+  }
+
+  void exodus_export::add_nodal_data_(const std::vector<scalar_type> &V,
+                                      size_type Q, const std::string &name) {
+    if (cur_step_ < 0) set_time(0.);
+    size_type step = size_type(cur_step_);
+    for (size_type q=0; q < Q; ++q) {
+      std::string nm = remove_spaces(exo_comp_name(name, q, Q));
+      // Exodus names are fixed-length; truncate here so the in-memory name
+      // matches the (truncated) name written to / read back from the file --
+      // otherwise a long name would be rejected on append.
+      if (nm.size() >= EXO_STRLEN) nm.resize(EXO_STRLEN - 1);
+      if (!vars_declared_) {
+        // step 0: record the variable (preserving order) and gather its values
+        // straight into the step-0 buffer it will be flushed from
+        bool seen = false;
+        for (const auto &n : var_names_) if (n == nm) { seen = true; break; }
+        if (!seen) var_names_.push_back(nm);
+        std::vector<scalar_type> &buf = step0_[nm];
+        buf.resize(nb_nodes_);
+        for (size_type i=0; i < nb_nodes_; ++i) buf[i] = V[i*Q+q];
+      } else {
+        auto it = var_id_.find(nm);
+        GMM_ASSERT1(it != var_id_.end(), "Exodus transient export: variable '"
+                    << nm << "' appeared after the first time step; the set of "
+                    "written fields must be the same at every step");
+        col_.resize(nb_nodes_);              // reused across components/steps
+        for (size_type i=0; i < nb_nodes_; ++i) col_[i] = V[i*Q+q];
+        size_t start[2] = { step, 0 }, count[2] = { 1, nb_nodes_ };
+        EXNC(nc_put_vara_double(ncid_, it->second, start, count, col_.data()));
+        bool already = false;            // record that this field got this step
+        for (const auto &n : step_written_) if (n == nm) { already = true; break; }
+        if (!already) step_written_.push_back(nm);
+      }
+    }
+  }
+
+  void exodus_export::define_transient_vars_() {
+    if (transient_definitions_ready_) return;
+    GMM_ASSERT1(!var_names_.empty() || region_field_,
+                "Exodus transient export: no variables to declare");
+    EXNC(nc_def_var(ncid_, "time_whole", NC_DOUBLE, 1, &d_time_, &v_time_));
+    deflate_var_(v_time_);
+    if (!var_names_.empty()) {
+      int d_nv;
+      EXNC(nc_def_dim(ncid_, "num_nod_var", var_names_.size(), &d_nv));
+      { int dd[2] = { d_nv, d_len_name_ };
+        EXNC(nc_def_var(ncid_, "name_nod_var", NC_CHAR, 2, dd, &v_nod_names_)); }
+      for (size_type k=0; k < var_names_.size(); ++k) {
+        std::ostringstream s; s << "vals_nod_var" << (k+1);
+        int dd[2] = { d_time_, d_num_nodes_ }, vid;
+        EXNC(nc_def_var(ncid_, s.str().c_str(), NC_DOUBLE, 2, dd, &vid));
+        deflate_var_(vid);
+        var_id_[var_names_[k]] = vid;
+      }
+    }
+
+    if (region_field_) {
+      int d_nev, d_blk;
+      EXNC(nc_def_dim(ncid_, "num_elem_var", 1, &d_nev));
+      { int dd[2] = { d_nev, d_len_name_ };
+        EXNC(nc_def_var(ncid_, "name_elem_var", NC_CHAR, 2, dd, &v_elem_names_)); }
+      EXNC(nc_inq_dimid(ncid_, "num_el_blk", &d_blk));
+      { int dd[2] = { d_blk, d_nev };
+        EXNC(nc_def_var(ncid_, "elem_var_tab", NC_INT, 2, dd, &v_elem_var_tab_));
+        deflate_var_(v_elem_var_tab_); }
+      elem_var_id_.resize(blocks_.size());
+      for (size_type b=0; b < blocks_.size(); ++b) {
+        std::ostringstream sd; sd << "num_el_in_blk" << (b+1);
+        int de; EXNC(nc_inq_dimid(ncid_, sd.str().c_str(), &de));
+        std::ostringstream sv; sv << "vals_elem_var1eb" << (b+1);
+        int dd[2] = { d_time_, de }, vid;
+        EXNC(nc_def_var(ncid_, sv.str().c_str(), NC_DOUBLE, 2, dd, &vid));
+        deflate_var_(vid);
+        elem_var_id_[b] = vid;
+      }
+    }
+    transient_definitions_ready_ = true;
+  }
+
+  void exodus_export::write_transient_metadata_() {
+    if (v_nod_names_ >= 0)
+      for (size_type k=0; k < var_names_.size(); ++k)
+        exo_put_string(ncid_, v_nod_names_, k, EXO_STRLEN, var_names_[k]);
+    if (v_elem_names_ >= 0) {
+      exo_put_string(ncid_, v_elem_names_, 0, EXO_STRLEN, "region");
+      std::vector<int> tab(blocks_.size(), 1);   // defined on every block
+      EXNC(nc_put_var_int(ncid_, v_elem_var_tab_, tab.data()));
+    }
+  }
+
+  /* Declare the transient NetCDF variables (once step 0's field set is known)
+     and flush the buffered step 0. From then on steps stream directly. */
+  void exodus_export::declare_transient_vars_() {
+    EXNC(nc_redef(ncid_));
+    define_transient_vars_();
+    EXNC(nc_enddef(ncid_));
+    write_transient_metadata_();
+    vars_declared_ = true;
+
+    for (const auto &kv : step0_) {
+      size_t start[2] = { size_t(cur_step_), 0 }, count[2] = { 1, nb_nodes_ };
+      EXNC(nc_put_vara_double(ncid_, var_id_[kv.first], start, count,
+                              kv.second.data()));
+      bool already = false;
+      for (const auto &n : step_written_) if (n == kv.first) already = true;
+      if (!already) step_written_.push_back(kv.first);
+    }
+    step0_.clear();
+    write_step_time_and_region_();
+    EXNC(nc_sync(ncid_));
+  }
+
+  void exodus_export::check_current_step_complete_() const {
+    if (cur_step_ < 0 || !vars_declared_) return;
+    if (append_mode_ && cur_step_ <= append_base_step_) return;
+    GMM_ASSERT1(step_written_.size() == var_names_.size(),
+                "Exodus transient export: time step " << cur_step_ << " wrote "
+                << step_written_.size() << " of " << var_names_.size()
+                << " field(s); every field must be written at every step");
+  }
+
+  void exodus_export::write_step_time_and_region_() {
+    if (cur_step_ < 0 || cur_time_written_) return;
+    GMM_ASSERT1(vars_declared_ && cur_time_valid_,
+                "Exodus transient export: no current time step");
+    size_t st = size_t(cur_step_), ct = 1;
+    EXNC(nc_put_vara_double(ncid_, v_time_, &st, &ct, &cur_time_));
+    if (!elem_var_id_.empty()) write_region_slab_(size_type(cur_step_));
+    cur_time_written_ = true;
+  }
+
+  void exodus_export::finish_current_step_(bool do_sync) {
+    if (cur_step_ < 0 || !cur_time_valid_) return;
+    if (!vars_declared_) declare_transient_vars_();
+    else {
+      check_current_step_complete_();
+      write_step_time_and_region_();
+      if (do_sync) EXNC(nc_sync(ncid_));
+    }
+  }
+
+  /* Write the (time-constant) "region" element variable for one step: every
+     element of block b gets that block's id. Cheap: O(num_elem) per step. */
+  void exodus_export::write_region_slab_(size_type step) {
+    for (size_type b=0; b < blocks_.size(); ++b) {
+      col_.assign(blocks_[b].convexes.size(), scalar_type(blocks_[b].block_id));
+      size_t start[2] = { step, 0 }, count[2] = { 1, blocks_[b].convexes.size() };
+      EXNC(nc_put_vara_double(ncid_, elem_var_id_[b], start, count, col_.data()));
+    }
+  }
+
+  void exodus_export::sync() {
+    if (!file_open_) return;
+    if (state_ < MESH_WRITTEN) write_mesh();
+    finish_current_step_(true);
+  }
+
+  void exodus_export::close() {
+    if (!file_open_) return;
+    try {
+      if (region_field_ && cur_step_ < 0) set_time(0.);
+      finish_current_step_(false);
+    } catch (...) {
+      nc_close(ncid_);
+      file_open_ = false;
+      throw;
+    }
+    EXNC(nc_close(ncid_));
+    file_open_ = false;
+  }
+
+
+  /* ********************************************************************* */
+  /*  Exodus import                                                        */
+  /* ********************************************************************* */
+
+  exodus_import::exodus_import(const std::string &fname)
+    : ncid_(-1), file_open_(false) {
+    int comp = 0;
+    EXNC(nc_open(fname.c_str(), NC_NOWRITE, &ncid_));
+    file_open_ = true; (void)comp;
+
+    /* transient variable names */
+    int d_nv;
+    if (nc_inq_dimid(ncid_, "num_nod_var", &d_nv) == NC_NOERR) {
+      size_t nv; EXNC(nc_inq_dimlen(ncid_, d_nv, &nv));
+      int v_names, d_name; size_t lname = EXO_STRLEN;
+      EXNC(nc_inq_varid(ncid_, "name_nod_var", &v_names));
+      if (nc_inq_dimid(ncid_, "len_name", &d_name) == NC_NOERR)
+        EXNC(nc_inq_dimlen(ncid_, d_name, &lname));
+      for (size_t k=0; k < nv; ++k) {
+        std::vector<char> buf(lname+1, '\0');
+        size_t start[2] = { k, 0 }, count[2] = { 1, lname };
+        EXNC(nc_get_vara_text(ncid_, v_names, start, count, buf.data()));
+        nodal_var_names_.push_back(std::string(buf.data()));
+      }
+    }
+    /* time values */
+    int d_t;
+    if (nc_inq_dimid(ncid_, "time_step", &d_t) == NC_NOERR) {
+      size_t nt = 0; nc_inq_dimlen(ncid_, d_t, &nt);
+      int v_t;
+      if (nt > 0 && nc_inq_varid(ncid_, "time_whole", &v_t) == NC_NOERR) {
+        times_.resize(nt);
+        EXNC(nc_get_var_double(ncid_, v_t, times_.data()));
+      }
+    }
+  }
+
+  exodus_import::~exodus_import() { try { close(); } catch (...) {} }
+
+  void exodus_import::close() {
+    if (file_open_) { nc_close(ncid_); file_open_ = false; }
+  }
+
+  void exodus_import::read_mesh(mesh &m) {
+    GMM_ASSERT1(file_open_, "Exodus file is closed");
+    int d_dim, d_nodes, d_blk;
+    size_t num_dim, num_nodes, num_blk;
+    EXNC(nc_inq_dimid(ncid_, "num_dim", &d_dim));
+    EXNC(nc_inq_dimlen(ncid_, d_dim, &num_dim));
+    GMM_ASSERT1(num_dim >= 1 && num_dim <= 3,
+                "Exodus import: unsupported spatial dimension " << num_dim
+                << " (1, 2 or 3 expected)");
+    EXNC(nc_inq_dimid(ncid_, "num_nodes", &d_nodes));
+    EXNC(nc_inq_dimlen(ncid_, d_nodes, &num_nodes));
+    EXNC(nc_inq_dimid(ncid_, "num_el_blk", &d_blk));
+    EXNC(nc_inq_dimlen(ncid_, d_blk, &num_blk));
+
+    /* coordinates */
+    std::vector<double> X(num_nodes,0.), Y(num_nodes,0.), Z(num_nodes,0.);
+    int v;
+    if (nc_inq_varid(ncid_, "coordx", &v) == NC_NOERR) {       // split layout (modern)
+      EXNC(nc_get_var_double(ncid_, v, X.data()));
+      if (num_dim >= 2 && nc_inq_varid(ncid_, "coordy", &v) == NC_NOERR)
+        EXNC(nc_get_var_double(ncid_, v, Y.data()));
+      if (num_dim >= 3 && nc_inq_varid(ncid_, "coordz", &v) == NC_NOERR)
+        EXNC(nc_get_var_double(ncid_, v, Z.data()));
+    } else if (nc_inq_varid(ncid_, "coord", &v) == NC_NOERR) { // packed (legacy)
+      std::vector<double> C(num_dim * num_nodes);              // coord(num_dim,num_nodes)
+      EXNC(nc_get_var_double(ncid_, v, C.data()));
+      for (size_t i=0; i < num_nodes; ++i) {
+        X[i] = C[i];
+        if (num_dim >= 2) Y[i] = C[num_nodes + i];
+        if (num_dim >= 3) Z[i] = C[2*num_nodes + i];
+      }
+    } else GMM_ASSERT1(false, "Exodus import: file has no nodal coordinates "
+                              "(neither 'coordx' nor packed 'coord')");
+
+    /* add every node so that getfem point id == Exodus node id (0-based) */
+    std::vector<size_type> node2pid(num_nodes);
+    node_pts_.assign(num_nodes, base_node(dim_type(num_dim)));
+    for (size_t i=0; i < num_nodes; ++i) {
+      base_node P(num_dim);
+      P[0] = X[i];
+      if (num_dim >= 2) P[1] = Y[i];
+      if (num_dim >= 3) P[2] = Z[i];
+      node_pts_[i] = P;
+      node2pid[i] = m.add_point(P, scalar_type(-1)); // no merge
+    }
+
+    /* block connectivity -> convexes; track the 1-based global Exodus element
+       id of each convex (and its topology) so side sets can be resolved. */
+    std::vector<size_type> elem_to_cv;
+    std::vector<exo_topo> elem_to_topo;
+    std::vector<bool> elem_to_shell;
+    for (size_t b=0; b < num_blk; ++b) {
+      std::ostringstream sc, sd1, sd2;
+      sc << "connect" << (b+1); sd1 << "num_el_in_blk" << (b+1);
+      sd2 << "num_nod_per_el" << (b+1);
+      int v_cn, de, dn; size_t nel, npe;
+      EXNC(nc_inq_varid(ncid_, sc.str().c_str(), &v_cn));
+      EXNC(nc_inq_dimid(ncid_, sd1.str().c_str(), &de));
+      EXNC(nc_inq_dimlen(ncid_, de, &nel));
+      EXNC(nc_inq_dimid(ncid_, sd2.str().c_str(), &dn));
+      EXNC(nc_inq_dimlen(ncid_, dn, &npe));
+
+      // read elem_type via the length-checked helper (the attribute can be
+      // longer than any fixed buffer in a foreign/malformed file)
+      std::string etype = exo_get_att_text(ncid_, v_cn, "elem_type");
+      GMM_ASSERT1(!etype.empty(),
+                  "Exodus import: block " << (b+1) << " has no 'elem_type'");
+      bool is_shell = exo_is_shell_type(etype);
+      exo_topo topo = exo_topo_of_name(etype);
+      bgeot::pgeometric_trans pgt = exo_pgt(topo, npe);
+      GMM_ASSERT1(pgt->nb_points() == npe,
+                  "Exodus block element type '" << etype << "' (" << npe
+                  << " nodes) is not supported for import");
+
+      /* inverse permutation: for each GetFEM geometric node, which Exodus
+         local position supplies it */
+      std::vector<base_node> gn(pgt->geometric_nodes().begin(),
+                                pgt->geometric_nodes().end());
+      std::vector<unsigned> perm = exo_build_perm(gn, exo_reference(topo, npe));
+      std::vector<unsigned> inv(npe);
+      for (size_type e=0; e < npe; ++e) inv[perm[e]] = unsigned(e);
+
+      std::vector<size_type> cvnodes(npe);
+      size_t chunk_elems =
+        std::max<size_t>(1, EXO_IO_CHUNK / std::max<size_t>(1, npe));
+      std::vector<int> conn(chunk_elems*npe);
+      for (size_t first=0; first < nel; first += chunk_elems) {
+        size_t ne = std::min(chunk_elems, nel - first);
+        size_t start[2] = { first, 0 }, count[2] = { ne, npe };
+        EXNC(nc_get_vara_int(ncid_, v_cn, start, count, conn.data()));
+        for (size_t el=0; el < ne; ++el) {
+          for (size_type g=0; g < npe; ++g) {
+            int cnode = conn[el*npe + inv[g]];        // 1-based Exodus node id
+            GMM_ASSERT1(cnode >= 1 && size_t(cnode) <= num_nodes,
+                        "Exodus import: connectivity node id " << cnode
+                        << " out of range [1," << num_nodes << "]");
+            cvnodes[g] = node2pid[size_t(cnode) - 1];
+          }
+          size_type ic = m.add_convex(pgt, cvnodes.begin());
+          elem_to_cv.push_back(ic);
+          elem_to_topo.push_back(topo);
+          elem_to_shell.push_back(is_shell);
+        }
+      }
+    }
+
+    /* side sets -> face regions (Exodus side-set id -> GetFEM region id) */
+    int d_nss;
+    if (nc_inq_dimid(ncid_, "num_side_sets", &d_nss) == NC_NOERR) {
+      size_t n_ss; EXNC(nc_inq_dimlen(ncid_, d_nss, &n_ss));
+      std::vector<int> ss_ids(n_ss);
+      if (nc_inq_varid(ncid_, "ss_prop1", &v) == NC_NOERR)
+        exo_get_ints(ncid_, v, n_ss, ss_ids.data());
+      else for (size_t i=0; i < n_ss; ++i) ss_ids[i] = int(i+1);
+      std::map<exo_topo, std::vector<unsigned> > finv_cache;
+      for (size_t i=0; i < n_ss; ++i) {
+        std::ostringstream se, sf, sd;
+        se << "elem_ss" << (i+1); sf << "side_ss" << (i+1);
+        sd << "num_side_ss" << (i+1);
+        int v_e, v_s, dss; size_t nside;
+        EXNC(nc_inq_dimid(ncid_, sd.str().c_str(), &dss));
+        EXNC(nc_inq_dimlen(ncid_, dss, &nside));
+        EXNC(nc_inq_varid(ncid_, se.str().c_str(), &v_e));
+        EXNC(nc_inq_varid(ncid_, sf.str().c_str(), &v_s));
+        std::vector<int> els(nside), sds(nside);
+        exo_get_ints(ncid_, v_e, nside, els.data());
+        exo_get_ints(ncid_, v_s, nside, sds.data());
+        mesh_region reg = m.region(size_type(ss_ids[i]));
+        for (size_t k=0; k < nside; ++k) {
+          int elem_id = els[k];                 // 1-based global element id
+          GMM_ASSERT1(elem_id >= 1 && size_t(elem_id) <= elem_to_cv.size(),
+                      "Exodus import: side set " << ss_ids[i]
+                      << " references element id " << elem_id
+                      << " out of range [1," << elem_to_cv.size() << "]");
+          size_t gid = size_t(elem_id);
+          GMM_ASSERT1(!elem_to_shell[gid-1],
+                      "Exodus import: side sets on SHELL elements are not "
+                      "supported because Exodus shell side numbering is not "
+                      "the same as GetFEM surface-element face numbering");
+          exo_topo topo = elem_to_topo[gid-1];
+          auto it = finv_cache.find(topo);
+          if (it == finv_cache.end()) {
+            std::vector<unsigned> fp = exo_face_perm(topo), finv(fp.size());
+            for (size_type f=0; f < fp.size(); ++f) finv[fp[f]] = unsigned(f);
+            it = finv_cache.emplace(topo, finv).first;
+          }
+          int side_id = sds[k];                 // 1-based Exodus side
+          GMM_ASSERT1(side_id >= 1 && size_t(side_id) <= it->second.size(),
+                      "Exodus import: side set " << ss_ids[i]
+                      << " references side " << side_id << " out of range "
+                      << "[1," << it->second.size() << "] for element "
+                      << elem_id);
+          size_t side = size_t(side_id);
+          reg.add(elem_to_cv[gid-1], short_type(it->second[side-1]));
+        }
+      }
+    }
+
+    /* element sets -> convex regions (Exodus element-set id -> region id) */
+    int d_nes;
+    if (nc_inq_dimid(ncid_, "num_elem_sets", &d_nes) == NC_NOERR) {
+      size_t n_es; EXNC(nc_inq_dimlen(ncid_, d_nes, &n_es));
+      std::vector<int> es_ids(n_es);
+      if (nc_inq_varid(ncid_, "els_prop1", &v) == NC_NOERR)
+        exo_get_ints(ncid_, v, n_es, es_ids.data());
+      else for (size_t i=0; i < n_es; ++i) es_ids[i] = int(i+1);
+      for (size_t i=0; i < n_es; ++i) {
+        std::ostringstream se, sd;
+        se << "elem_els" << (i+1); sd << "num_ele_els" << (i+1);
+        int v_e, des; size_t nel;
+        EXNC(nc_inq_dimid(ncid_, sd.str().c_str(), &des));
+        EXNC(nc_inq_dimlen(ncid_, des, &nel));
+        EXNC(nc_inq_varid(ncid_, se.str().c_str(), &v_e));
+        std::vector<int> els(nel);
+        exo_get_ints(ncid_, v_e, nel, els.data());
+        mesh_region reg = m.region(size_type(es_ids[i]));
+        for (size_t k=0; k < nel; ++k) {
+          int elem_id = els[k];
+          GMM_ASSERT1(elem_id >= 1 && size_t(elem_id) <= elem_to_cv.size(),
+                      "Exodus import: element set " << es_ids[i]
+                      << " references element id " << elem_id
+                      << " out of range [1," << elem_to_cv.size() << "]");
+          size_t gid = size_t(elem_id);
+          reg.add(elem_to_cv[gid-1]);
+        }
+      }
+    }
+
+    /* node sets -> recorded for node_set() (GetFEM has no node region) */
+    int d_nns;
+    if (nc_inq_dimid(ncid_, "num_node_sets", &d_nns) == NC_NOERR) {
+      size_t n_ns; EXNC(nc_inq_dimlen(ncid_, d_nns, &n_ns));
+      std::vector<int> ns_ids(n_ns);
+      if (nc_inq_varid(ncid_, "ns_prop1", &v) == NC_NOERR)
+        exo_get_ints(ncid_, v, n_ns, ns_ids.data());
+      else for (size_t i=0; i < n_ns; ++i) ns_ids[i] = int(i+1);
+      for (size_t i=0; i < n_ns; ++i) {
+        std::ostringstream sn, sd;
+        sn << "node_ns" << (i+1); sd << "num_nod_ns" << (i+1);
+        int v_n, dns; size_t nn;
+        EXNC(nc_inq_dimid(ncid_, sd.str().c_str(), &dns));
+        EXNC(nc_inq_dimlen(ncid_, dns, &nn));
+        EXNC(nc_inq_varid(ncid_, sn.str().c_str(), &v_n));
+        std::vector<int> nodes(nn);
+        exo_get_ints(ncid_, v_n, nn, nodes.data());
+        std::vector<size_type> pts(nn);
+        for (size_t k=0; k < nn; ++k) {
+          int node_id = nodes[k];
+          GMM_ASSERT1(node_id >= 1 && size_t(node_id) <= node2pid.size(),
+                      "Exodus import: node set " << ns_ids[i]
+                      << " references node id " << node_id
+                      << " out of range [1," << node2pid.size() << "]");
+          pts[k] = node2pid[size_t(node_id) - 1]; // 1-based -> 0-based node
+        }
+        node_set_ids_.push_back(ns_ids[i]);
+        node_sets_[ns_ids[i]] = pts;
+      }
+    }
+  }
+
+  const std::vector<size_type> &exodus_import::node_set(int id) const {
+    static const std::vector<size_type> empty;
+    auto it = node_sets_.find(id);
+    return (it == node_sets_.end()) ? empty : it->second;
+  }
+
+  void exodus_import::build_mesh_fem(const mesh &m, mesh_fem &mf) const {
+    mf = mesh_fem(m);
+    mf.set_qdim(1);
+    for (dal::bv_visitor cv(m.convex_index()); !cv.finished(); ++cv) {
+      bgeot::pgeometric_trans pgt = m.trans_of_convex(cv);
+      pfem pf;
+      // keep the matching SERENDIPITY element for incomplete geotrans, so the
+      // mesh_fem has exactly the file's nodes (dof i <-> Exodus node i); a
+      // complete classical_fem would add interior dofs absent from the file
+      if (pgt == bgeot::Q2_incomplete_geotrans(2))
+        pf = fem_descriptor("FEM_Q2_INCOMPLETE(2)");
+      else if (pgt == bgeot::Q2_incomplete_geotrans(3))
+        pf = fem_descriptor("FEM_Q2_INCOMPLETE(3)");
+      else if (pgt == bgeot::prism_incomplete_P2_geotrans())
+        pf = fem_descriptor("FEM_PRISM_INCOMPLETE_P2");
+      else {
+        short_type degree =
+          (pgt->structure() != pgt->basic_structure()) ? 2 : 1;
+        pf = classical_fem(pgt, degree, true);
+      }
+      mf.set_finite_element(cv, pf);
+    }
+
+    /* The imported mesh was built with point id == Exodus node id.  GetFEM's
+       natural mesh_fem enumeration is not point-id ordered, so expose a reduced
+       mesh_fem whose dof i is exactly Exodus node i. */
+    size_type nn = node_pts_.size();
+    GMM_ASSERT1(nn > 0 || m.convex_index().card() == 0,
+                "Exodus import: read_mesh() must be called before build_mesh_fem()");
+    std::vector<size_type> node_to_basic(nn, size_type(-1));
+    for (dal::bv_visitor cv(m.convex_index()); !cv.finished(); ++cv) {
+      const bgeot::mesh_structure::ind_cv_ct &pts = m.ind_points_of_convex(cv);
+      mesh_fem::ind_dof_ct dofs = mf.ind_basic_dof_of_element(cv);
+      GMM_ASSERT1(pts.size() == dofs.size(),
+                  "Exodus import: imported finite element does not have one "
+                  "basic dof per Exodus node");
+      for (size_type j=0; j < pts.size(); ++j) {
+        size_type n = pts[j], d = dofs[j];
+        GMM_ASSERT1(n < nn, "Exodus import: mesh point id " << n
+                    << " is outside the Exodus node range [0," << nn << ")");
+        if (node_to_basic[n] == size_type(-1)) node_to_basic[n] = d;
+        else GMM_ASSERT1(node_to_basic[n] == d,
+                         "Exodus import: node " << n
+                         << " maps to inconsistent mesh_fem dofs");
+      }
+    }
+    GMM_ASSERT1(mf.nb_basic_dof() == nn,
+                "Exodus import: the mesh_fem has " << mf.nb_basic_dof()
+                << " basic dofs but the file has " << nn
+                << " nodes; isolated Exodus nodes cannot be represented by "
+                "this mesh_fem");
+
+    gmm::row_matrix<gmm::rsvector<scalar_type> > R(nn, mf.nb_basic_dof());
+    gmm::row_matrix<gmm::rsvector<scalar_type> > E(mf.nb_basic_dof(), nn);
+    for (size_type n=0; n < nn; ++n) {
+      GMM_ASSERT1(node_to_basic[n] != size_type(-1),
+                  "Exodus import: node " << n
+                  << " is not attached to any imported element");
+      R(n, node_to_basic[n]) = scalar_type(1);
+      E(node_to_basic[n], n) = scalar_type(1);
+    }
+    mf.set_reduction_matrices(R, E);
+  }
+
+  void exodus_import::read_nodal_var_(const std::string &name, size_type step,
+                                      std::vector<scalar_type> &U) const {
+    GMM_ASSERT1(file_open_, "Exodus file is closed");
+    size_type k = size_type(-1);
+    for (size_type i=0; i < nodal_var_names_.size(); ++i)
+      if (nodal_var_names_[i] == name) { k = i; break; }
+    GMM_ASSERT1(k != size_type(-1),
+                "no nodal variable named '" << name << "' in the Exodus file");
+    GMM_ASSERT1(step < times_.size() || (times_.empty() && step == 0),
+                "time step " << step << " out of range");
+    int d_nodes; size_t num_nodes;
+    EXNC(nc_inq_dimid(ncid_, "num_nodes", &d_nodes));
+    EXNC(nc_inq_dimlen(ncid_, d_nodes, &num_nodes));
+    std::ostringstream s; s << "vals_nod_var" << (k+1);
+    int v; EXNC(nc_inq_varid(ncid_, s.str().c_str(), &v));
+    U.assign(num_nodes, 0.);
+    size_t start[2] = { step, 0 }, count[2] = { 1, num_nodes };
+    EXNC(nc_get_vara_double(ncid_, v, start, count, U.data()));
+  }
+
+  void import_mesh_exodus(const std::string &fname, mesh &m) {
+    exodus_import imp(fname);
+    imp.read_mesh(m);
+  }
+
+} /* end of namespace getfem */
+
+#endif /* GETFEM_HAVE_EXODUS */

--- a/src/getfem_import.cc
+++ b/src/getfem_import.cc
@@ -25,6 +25,7 @@
 #include "getfem/getfem_mesh.h"
 #include "getfem/getfem_import.h"
 #include "getfem/getfem_regular_meshes.h"
+#include "getfem/getfem_exodus.h"
 
 namespace getfem {
 
@@ -1544,6 +1545,15 @@ namespace getfem {
         { regular_ball_mesh(m, filename); return; }
       else if (bgeot::casecmp(format,"structured_ball_shell")==0)
         { regular_ball_shell_mesh(m, filename); return; }
+      else if (bgeot::casecmp(format,"exodus")==0) {
+        /* Exodus is a binary (NetCDF) format, opened by name, not by stream */
+#ifdef GETFEM_HAVE_EXODUS
+        import_mesh_exodus(filename, m); return;
+#else
+        GMM_ASSERT1(false, "GetFEM was built without Exodus support; "
+                    "reconfigure with --enable-exodus");
+#endif
+      }
 
       std::ifstream f(filename.c_str());
       GMM_ASSERT1(f.good(), "can't open file " << filename);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -22,7 +22,15 @@ optpl = test_mesh_im_level_set.pl                \
         test_mesh_generation.pl
 else
 optprogs =
-optpl = 
+optpl =
+endif
+
+if EXODUS
+exodus_progs = test_exodus
+exodus_pl = test_exodus.pl
+else
+exodus_progs =
+exodus_pl =
 endif
 
 check_PROGRAMS =             \
@@ -56,6 +64,7 @@ check_PROGRAMS =             \
   nonlinear_membrane         \
   schwarz_additive           \
   $(optprogs)                \
+  $(exodus_progs)            \
   plasticity                 \
   bilaplacian                \
   heat_equation              \
@@ -75,7 +84,7 @@ CLEANFILES = \
   ii_files/* auto_gmm* dyn*.txt *.sl time FN0 *.vtk *.vtu             \
   nonlinear_elastostatic.U crack.mesh cut.mesh nonlinear_membrane.mfd \
   nonlinear_membrane.mesh test_range_basis.mesh nonlinear_membrane.mf \
-  Q2_incomplete.pos Q2_incomplete.msh 
+  Q2_incomplete.pos Q2_incomplete.msh *.exo
 
 dynamic_array_SOURCES = dynamic_array.cc 
 dynamic_tas_SOURCES = dynamic_tas.cc 
@@ -119,6 +128,7 @@ wave_equation_SOURCES = wave_equation.cc
 cyl_slicer_SOURCES = cyl_slicer.cc
 test_continuation_SOURCES = test_continuation.cc
 test_gmm_matrix_functions_SOURCES = test_gmm_matrix_functions.cc
+test_exodus_SOURCES = test_exodus.cc
 
 AM_CPPFLAGS = -I$(top_srcdir)/src -I../src
 LDADD    = ../src/libgetfem.la -lm @SUPLDFLAGS@ -lstdc++
@@ -150,6 +160,7 @@ TESTS =                         \
   stokes.pl                     \
   plate.pl                      \
   $(optpl)                      \
+  $(exodus_pl)                  \
   nonlinear_elastostatic.pl     \
   nonlinear_membrane.pl         \
   test_continuation.pl          \
@@ -250,6 +261,8 @@ EXTRA_DIST =                                         \
   meshes/punch2D_1.mesh                              \
   meshes/punch2D_2.mesh                              \
   meshes/multi_body.mesh                             \
-  meshes/donut_regulier_512_elements.mesh
+  meshes/donut_regulier_512_elements.mesh            \
+  test_exodus.pl                                     \
+  test_exodus.cc
 
 LOG_COMPILER = perl

--- a/tests/test_exodus.cc
+++ b/tests/test_exodus.cc
@@ -1,0 +1,820 @@
+/*===========================================================================
+
+ Copyright (C) 2026 GetFEM contributors
+
+ This file is a part of GetFEM
+
+ GetFEM  is  free software;  you  can  redistribute  it  and/or modify it
+ under  the  terms  of the  GNU  Lesser General Public License as published
+ by  the  Free Software Foundation;  either version 3 of the License,  or
+ (at your option) any later version along with the GCC Runtime Library
+ Exception either version 3.1 or (at your option) any later version.
+ This program  is  distributed  in  the  hope  that it will be useful,  but
+ WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ or  FITNESS  FOR  A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ License and GCC Runtime Library Exception for more details.
+ You  should  have received a copy of the GNU Lesser General Public License
+ along  with  this program. If not, see https://www.gnu.org/licenses/.
+
+===========================================================================*/
+
+// Round-trip tests for the Exodus II import/export (getfem_exodus.{h,cc}).
+//   * for several element types: write a mesh + a nodal field, read it back,
+//     and check the geometry and the field values are recovered;
+//   * a transient (time-series) field written to a single Exodus file and
+//     read back step by step.
+
+#include "getfem/getfem_exodus.h"
+#include "getfem/getfem_regular_meshes.h"
+#include <algorithm>
+#include <set>
+
+#ifdef GETFEM_HAVE_EXODUS
+
+#include <netcdf.h>      // raw NetCDF reads to check Exodus entities directly
+#include <sstream>
+
+using std::cout;
+using std::endl;
+using getfem::size_type;
+using getfem::scalar_type;
+using getfem::base_node;
+using bgeot::dim_type;
+using bgeot::short_type;
+
+static int nb_errors = 0;
+static void check(bool ok, const std::string &what) {
+  if (!ok) { ++nb_errors; cout << "  *** error has been detected: " << what << endl; }
+}
+
+template<class F>
+static void expect_gmm_error(const std::string &what, F f,
+                             const std::string &needle) {
+  bool got = false;
+  try { f(); }
+  catch (const gmm::gmm_error &e) {
+    got = true;
+    std::string msg = e.what();
+    check(needle.empty() || msg.find(needle) != std::string::npos,
+          what + ": error message contains '" + needle + "'");
+  }
+  catch (...) {
+    got = true;
+    check(false, what + ": unexpected exception type");
+  }
+  check(got, what + ": expected GetFEM error");
+}
+
+// an arbitrary smooth scalar field, sampled at node coordinates
+static scalar_type field(const base_node &p, scalar_type t = 1.) {
+  scalar_type v = 1. + 2.*p[0] + 0.3*p[0]*p[0];
+  if (p.size() > 1) v += 3.*p[1] - 0.2*p[1]*p[1];
+  if (p.size() > 2) v += 4.*p[2];
+  return t*v;
+}
+
+// max |value at node i - field(node coord i)| over the re-read file
+static scalar_type
+node_value_error(const getfem::exodus_import &imp,
+                 const std::vector<scalar_type> &U, scalar_type t) {
+  const std::vector<base_node> &P = imp.node_points();
+  scalar_type e = 0.;
+  for (size_type i=0; i < U.size(); ++i)
+    e = std::max(e, gmm::abs(U[i] - field(P[i], t)));
+  return e;
+}
+
+static void test_roundtrip(const std::string &gt, short_type order,
+                           const std::vector<size_type> &nsub) {
+  std::string tag = gt + " (order " + char('0'+order) + ")";
+  const char *fname = "test_exodus_tmp.exo";
+
+  getfem::mesh m;
+  getfem::regular_unit_mesh(m, nsub, bgeot::geometric_trans_descriptor(gt));
+  getfem::mesh_fem mf(m);
+  mf.set_classical_finite_element(order);
+
+  std::vector<scalar_type> U(mf.nb_dof());
+  for (size_type i=0; i < mf.nb_dof(); ++i) U[i] = field(mf.point_of_basic_dof(i));
+
+  { getfem::exodus_export ex(fname);
+    ex.exporting(mf); ex.write_mesh();
+    ex.write_point_data(mf, U, "u"); }              // closed by destructor
+
+  getfem::mesh m2;
+  getfem::exodus_import imp(fname);
+  imp.read_mesh(m2);
+
+  check(m2.convex_index().card() == m.convex_index().card(),
+        tag + ": number of elements");
+
+  std::vector<scalar_type> Ub;
+  imp.read_nodal_var("u", 0, Ub);
+  check(Ub.size() == imp.node_points().size(), tag + ": variable length");
+  scalar_type err = node_value_error(imp, Ub, 1.);
+  check(err < 1e-10, tag + ": field values (err=" + std::to_string(err) + ")");
+  cout << "  " << tag << ": " << m2.convex_index().card() << " elements, "
+       << Ub.size() << " nodes, value error " << err << endl;
+}
+
+static void test_time_series() {
+  const char *fname = "test_exodus_series.exo";
+  const size_type nstep = 5;
+  std::vector<scalar_type> tvals = {0., 0.25, 0.5, 0.75, 1.0};
+
+  getfem::mesh m;
+  getfem::regular_unit_mesh(m, {3,3}, bgeot::geometric_trans_descriptor("GT_QK(2,1)"));
+  getfem::mesh_fem mf(m);
+  mf.set_classical_finite_element(2);              // -> QUAD9
+
+  // write the transient field to a single file
+  { getfem::exodus_export ex(fname);
+    ex.exporting(mf); ex.write_mesh();
+    for (size_type s=0; s < nstep; ++s) {
+      std::vector<scalar_type> U(mf.nb_dof());
+      for (size_type i=0; i < mf.nb_dof(); ++i)
+        U[i] = field(mf.point_of_basic_dof(i), tvals[s]);
+      ex.set_time(tvals[s]);
+      ex.write_point_data(mf, U, "u");
+      ex.sync();
+      getfem::exodus_import live(fname);
+      check(live.nb_steps() == s+1, "time series live sync: visible step count");
+    }
+  }
+
+  getfem::mesh m2;
+  getfem::exodus_import imp(fname);
+  imp.read_mesh(m2);
+  check(imp.nb_steps() == nstep, "time series: number of steps");
+  scalar_type terr = 0.;
+  for (size_type s=0; s < imp.times().size(); ++s)
+    terr = std::max(terr, gmm::abs(imp.times()[s] - tvals[s]));
+  check(terr < 1e-12, "time series: time values");
+
+  scalar_type maxerr = 0.;
+  for (size_type s=0; s < nstep; ++s) {
+    std::vector<scalar_type> Ub;
+    imp.read_nodal_var("u", s, Ub);
+    maxerr = std::max(maxerr, node_value_error(imp, Ub, tvals[s]));
+  }
+  check(maxerr < 1e-10, "time series: field values per step");
+  cout << "  time series: " << nstep << " steps, max value error "
+       << maxerr << endl;
+}
+
+// export a mesh whose outer faces form region 7, read it back, and check the
+// boundary side set survived as a face region
+static void test_region_roundtrip(const std::string &gt,
+                                   const std::vector<size_type> &nsub) {
+  std::string tag = gt + " regions";
+  const char *fname = "test_exodus_region.exo";
+  getfem::mesh m;
+  getfem::regular_unit_mesh(m, nsub, bgeot::geometric_trans_descriptor(gt));
+  getfem::outer_faces_of_mesh(m, m.region(7));
+  size_type n_orig = 0;
+  for (getfem::mr_visitor i(m.region(7)); !i.finished(); ++i)
+    if (i.is_face()) ++n_orig;
+
+  { getfem::exodus_export ex(fname); ex.exporting(m); ex.write_mesh(); }
+
+  getfem::mesh m2;
+  getfem::import_mesh_exodus(fname, m2);
+  check(m2.regions_index().is_in(7), tag + ": region present");
+
+  size_type n_imp = 0;
+  for (getfem::mr_visitor i(m2.region(7)); !i.finished(); ++i)
+    if (i.is_face()) ++n_imp;
+  check(n_imp == n_orig, tag + ": boundary face count");
+
+  // every face of the imported region must be a genuine boundary face of m2
+  getfem::outer_faces_of_mesh(m2, m2.region(8));
+  std::set<std::pair<size_type,short_type> > outer;
+  for (getfem::mr_visitor i(m2.region(8)); !i.finished(); ++i)
+    if (i.is_face()) outer.insert(std::make_pair(i.cv(), i.f()));
+  bool all_outer = true;
+  for (getfem::mr_visitor i(m2.region(7)); !i.finished(); ++i)
+    if (i.is_face() && !outer.count(std::make_pair(i.cv(), i.f())))
+      all_outer = false;
+  check(all_outer, tag + ": region faces are genuine boundary faces");
+  cout << "  " << tag << ": " << n_imp << "/" << n_orig
+       << " boundary faces round-tripped" << endl;
+}
+
+// export a mesh with a convex (volume) region, read it back, and check the
+// region (Exodus element set) and its node set survived
+static void test_volume_region_roundtrip(const std::string &gt,
+                                          const std::vector<size_type> &nsub) {
+  std::string tag = gt + " volume region";
+  const char *fname = "test_exodus_vol.exo";
+  getfem::mesh m;
+  getfem::regular_unit_mesh(m, nsub, bgeot::geometric_trans_descriptor(gt));
+  { size_type c = 0;
+    for (dal::bv_visitor cv(m.convex_index()); !cv.finished(); ++cv, ++c)
+      if (c % 2 == 0) m.region(5).add(cv); }
+
+  // Identify the region's convexes by their centroid, not by convex id: the
+  // export gives each volume region its own Exodus element block, and Exodus
+  // numbers elements block by block, so the imported convex ids are legitimately
+  // renumbered. Coordinates round-trip exactly, so centroid sets must match.
+  auto region_centroids = [](const getfem::mesh &mm, size_type rid) {
+    std::set<std::vector<double> > s;
+    for (getfem::mr_visitor i(mm.region(rid)); !i.finished(); ++i)
+      if (!i.is_face()) {
+        auto pts = mm.points_of_convex(i.cv());
+        std::vector<double> g(mm.dim(), 0.);
+        for (size_type k=0; k < pts.size(); ++k)
+          for (size_type d=0; d < size_type(mm.dim()); ++d) g[d] += pts[k][d];
+        for (double &x : g) x /= double(pts.size());
+        s.insert(g);
+      }
+    return s;
+  };
+  std::set<std::vector<double> > orig = region_centroids(m, 5);
+
+  { getfem::exodus_export ex(fname); ex.exporting(m); ex.write_mesh(); }
+
+  getfem::mesh m2;
+  getfem::exodus_import imp(fname);
+  imp.read_mesh(m2);
+  check(m2.regions_index().is_in(5), tag + ": region present");
+  std::set<std::vector<double> > got = region_centroids(m2, 5);
+  check(got == orig, tag + ": convex set (by centroid)");
+  check(!imp.node_set(5).empty(), tag + ": node set present");
+  cout << "  " << tag << ": " << got.size() << "/" << orig.size()
+       << " convexes, " << imp.node_set(5).size() << " nodes in node set" << endl;
+}
+
+// reopen with the raw NetCDF API and check the "region" element variable, the
+// identity element/node number maps, and named element sets
+static void test_cell_var_and_names(const std::string &gt,
+                                    const std::vector<size_type> &nsub) {
+  std::string tag = gt + " cell var/names";
+  const char *fname = "test_exodus_cell.exo";
+  getfem::mesh m;
+  getfem::regular_unit_mesh(m, nsub, bgeot::geometric_trans_descriptor(gt));
+  { size_type c = 0;                       // two disjoint volume regions
+    for (dal::bv_visitor cv(m.convex_index()); !cv.finished(); ++cv, ++c)
+      m.region(c % 2 ? 6 : 5).add(cv); }
+  getfem::mesh_fem mf(m);
+  mf.set_classical_finite_element(1);
+  std::vector<scalar_type> U(mf.nb_dof());
+  for (size_type i=0; i < mf.nb_dof(); ++i) U[i] = field(mf.point_of_basic_dof(i));
+  { getfem::exodus_export ex(fname);
+    ex.enable_region_field();                 // opt in to the "region" cell var
+    ex.set_region_name(5, "core"); ex.set_region_name(6, "shell");
+    ex.exporting(mf); ex.write_mesh(); ex.write_point_data(mf, U, "u"); }
+
+  int nc = -1;
+  check(nc_open(fname, NC_NOWRITE, &nc) == NC_NOERR, tag + ": reopen file");
+  if (nc < 0) return;
+
+  size_t lname = 32;
+  { int dd; if (nc_inq_dimid(nc, "len_name", &dd) == NC_NOERR)
+              nc_inq_dimlen(nc, dd, &lname); }
+  auto read_name = [&](int v, size_t row) {
+    std::vector<char> buf(lname + 1, '\0');
+    size_t st[2] = { row, 0 }, ct[2] = { 1, lname };
+    nc_get_vara_text(nc, v, st, ct, buf.data());
+    return std::string(buf.data());
+  };
+
+  // (1) exactly one element variable, named "region"
+  int d; size_t nev = 0;
+  bool has_ev = (nc_inq_dimid(nc, "num_elem_var", &d) == NC_NOERR);
+  if (has_ev) nc_inq_dimlen(nc, d, &nev);
+  check(has_ev && nev == 1, tag + ": one element variable");
+  { int v; if (nc_inq_varid(nc, "name_elem_var", &v) == NC_NOERR)
+      check(read_name(v, 0) == "region", tag + ": element var named 'region'"); }
+
+  // (2) every element's region value equals its block id
+  int d_blk; size_t nblk = 0;
+  nc_inq_dimid(nc, "num_el_blk", &d_blk); nc_inq_dimlen(nc, d_blk, &nblk);
+  std::vector<int> ebp(nblk);
+  { int v; nc_inq_varid(nc, "eb_prop1", &v); nc_get_var_int(nc, v, ebp.data()); }
+  bool vals_ok = true;
+  for (size_t b=0; b < nblk; ++b) {
+    std::ostringstream sv, sd;
+    sv << "vals_elem_var1eb" << (b+1); sd << "num_el_in_blk" << (b+1);
+    int vv, dd; size_t ne = 0;
+    nc_inq_dimid(nc, sd.str().c_str(), &dd); nc_inq_dimlen(nc, dd, &ne);
+    nc_inq_varid(nc, sv.str().c_str(), &vv);
+    std::vector<double> vals(ne);
+    size_t st[2] = { 0, 0 }, ct[2] = { 1, ne };
+    nc_get_vara_double(nc, vv, st, ct, vals.data());
+    for (size_t e=0; e < ne; ++e) if (int(vals[e]) != ebp[b]) vals_ok = false;
+  }
+  check(vals_ok, tag + ": region value == block id");
+
+  // (3) identity element/node number maps
+  auto identity = [&](const char *name, const char *dimn) {
+    int v, dd; size_t n = 0;
+    if (nc_inq_varid(nc, name, &v) != NC_NOERR) return false;
+    nc_inq_dimid(nc, dimn, &dd); nc_inq_dimlen(nc, dd, &n);
+    std::vector<int> a(n); nc_get_var_int(nc, v, a.data());
+    for (size_t i=0; i < n; ++i) if (a[i] != int(i)+1) return false;
+    return true;
+  };
+  check(identity("elem_num_map", "num_elem"),  tag + ": elem_num_map identity");
+  check(identity("node_num_map", "num_nodes"), tag + ": node_num_map identity");
+
+  // (4) element-set names (region 5 -> "core", region 6 -> "shell")
+  { int dd; size_t nes = 0;
+    nc_inq_dimid(nc, "num_elem_sets", &dd); nc_inq_dimlen(nc, dd, &nes);
+    std::vector<int> esp(nes); int v, vn;
+    nc_inq_varid(nc, "els_prop1", &v); nc_get_var_int(nc, v, esp.data());
+    bool names_ok = (nc_inq_varid(nc, "els_names", &vn) == NC_NOERR);
+    for (size_t i=0; names_ok && i < nes; ++i) {
+      std::string want = (esp[i]==5) ? "core" : (esp[i]==6) ? "shell" : "";
+      if (read_name(vn, i) != want) names_ok = false;
+    }
+    check(names_ok, tag + ": element-set names");
+  }
+  nc_close(nc);
+
+  // (5) a mesh-only export (no field -> no time step) has no element variable
+  { const char *f2 = "test_exodus_meshonly.exo";
+    { getfem::exodus_export ex(f2); ex.exporting(m); ex.write_mesh(); }
+    int n2; nc_open(f2, NC_NOWRITE, &n2);
+    int dd;
+    check(nc_inq_dimid(n2, "num_elem_var", &dd) == NC_EBADDIM,
+          tag + ": mesh-only export has no element variable");
+    nc_close(n2);
+  }
+
+  // (6) mesh-only export with explicit region_field writes one static step
+  { const char *f3 = "test_exodus_meshonly_region.exo";
+    { getfem::exodus_export ex(f3);
+      ex.enable_region_field(); ex.exporting(m); ex.write_mesh(); ex.close(); }
+    int n3; nc_open(f3, NC_NOWRITE, &n3);
+    int dd; size_t nev_region = 0, nt = 0;
+    check(nc_inq_dimid(n3, "num_elem_var", &dd) == NC_NOERR,
+          tag + ": mesh-only region field has elem var dim");
+    nc_inq_dimlen(n3, dd, &nev_region);
+    check(nev_region == 1, tag + ": mesh-only region field has one elem var");
+    nc_inq_dimid(n3, "time_step", &dd); nc_inq_dimlen(n3, dd, &nt);
+    check(nt == 1, tag + ": mesh-only region field has one time step");
+    nc_close(n3);
+  }
+  cout << "  " << tag << ": region cell var, id maps, set names OK" << endl;
+}
+
+// import a hand-written legacy file using the packed coord(num_dim,num_nodes)
+// layout (our exporter only writes split coordx/y/z, so this needs raw NetCDF)
+static void test_packed_coord_import() {
+  std::string tag = "packed coord import";
+  const char *fname = "test_exodus_packed.exo";
+  int nc, st = 0;          // deterministic setup; accumulate any NetCDF error
+  st |= nc_create(fname, NC_CLOBBER | NC_64BIT_OFFSET, &nc);
+  int d_dim, d_nodes, d_blk, d_ne, d_npe, d_time;
+  st |= nc_def_dim(nc, "num_dim", 2, &d_dim);
+  st |= nc_def_dim(nc, "num_nodes", 4, &d_nodes);
+  st |= nc_def_dim(nc, "num_el_blk", 1, &d_blk);
+  st |= nc_def_dim(nc, "num_el_in_blk1", 1, &d_ne);
+  st |= nc_def_dim(nc, "num_nod_per_el1", 4, &d_npe);
+  st |= nc_def_dim(nc, "time_step", NC_UNLIMITED, &d_time);
+  int v_coord, v_conn, v_ebp;
+  { int dd[2] = { d_dim, d_nodes };
+    st |= nc_def_var(nc, "coord", NC_DOUBLE, 2, dd, &v_coord); }
+  { int dd[2] = { d_ne, d_npe };
+    st |= nc_def_var(nc, "connect1", NC_INT, 2, dd, &v_conn); }
+  st |= nc_put_att_text(nc, v_conn, "elem_type", 5, "QUAD4");
+  st |= nc_def_var(nc, "eb_prop1", NC_INT, 1, &d_blk, &v_ebp);
+  st |= nc_enddef(nc);
+  double coord[8] = { 0.,1.,1.,0.,  0.,0.,1.,1. };  // packed: all x, then all y
+  st |= nc_put_var_double(nc, v_coord, coord);
+  int conn[4] = { 1, 2, 3, 4 };
+  st |= nc_put_var_int(nc, v_conn, conn);
+  int ebp[1] = { 1 };
+  st |= nc_put_var_int(nc, v_ebp, ebp);
+  st |= nc_close(nc);
+  check(st == NC_NOERR, tag + ": wrote legacy fixture");
+
+  getfem::mesh m;
+  getfem::exodus_import imp(fname);
+  imp.read_mesh(m);
+  const std::vector<base_node> &P = imp.node_points();
+  check(P.size() == 4 && m.convex_index().card() == 1,
+        tag + ": 1 quad, 4 nodes");
+  check(gmm::abs(P[0][0]-0.) < 1e-12 && gmm::abs(P[0][1]-0.) < 1e-12 &&
+        gmm::abs(P[2][0]-1.) < 1e-12 && gmm::abs(P[2][1]-1.) < 1e-12,
+        tag + ": coordinates recovered from packed layout");
+  expect_gmm_error(tag + ": append refused without fingerprint", [&]() {
+    getfem::mesh_fem mf(m); mf.set_classical_finite_element(1);
+    getfem::exodus_export ex(fname, true);
+    ex.exporting(mf);
+  }, "fingerprint");
+  cout << "  " << tag << ": " << m.convex_index().card() << " element, "
+       << P.size() << " nodes" << endl;
+}
+
+static void test_import_build_mesh_fem_node_order() {
+  std::string tag = "import build_mesh_fem node order";
+  const char *fname = "test_exodus_node_order.exo";
+  int nc, st = 0;
+  st |= nc_create(fname, NC_CLOBBER | NC_64BIT_OFFSET, &nc);
+  int d_dim, d_nodes, d_blk, d_ne, d_npe, d_time, d_name, d_nv;
+  st |= nc_def_dim(nc, "num_dim", 2, &d_dim);
+  st |= nc_def_dim(nc, "num_nodes", 4, &d_nodes);
+  st |= nc_def_dim(nc, "num_el_blk", 1, &d_blk);
+  st |= nc_def_dim(nc, "num_el_in_blk1", 1, &d_ne);
+  st |= nc_def_dim(nc, "num_nod_per_el1", 4, &d_npe);
+  st |= nc_def_dim(nc, "time_step", NC_UNLIMITED, &d_time);
+  st |= nc_def_dim(nc, "len_name", 33, &d_name);
+  st |= nc_def_dim(nc, "num_nod_var", 1, &d_nv);
+  int v_x, v_y, v_conn, v_ebp, v_time, v_nvn, v_u;
+  st |= nc_def_var(nc, "coordx", NC_DOUBLE, 1, &d_nodes, &v_x);
+  st |= nc_def_var(nc, "coordy", NC_DOUBLE, 1, &d_nodes, &v_y);
+  { int dd[2] = { d_ne, d_npe };
+    st |= nc_def_var(nc, "connect1", NC_INT, 2, dd, &v_conn); }
+  st |= nc_put_att_text(nc, v_conn, "elem_type", 5, "QUAD4");
+  st |= nc_def_var(nc, "eb_prop1", NC_INT, 1, &d_blk, &v_ebp);
+  st |= nc_def_var(nc, "time_whole", NC_DOUBLE, 1, &d_time, &v_time);
+  { int dd[2] = { d_nv, d_name };
+    st |= nc_def_var(nc, "name_nod_var", NC_CHAR, 2, dd, &v_nvn); }
+  { int dd[2] = { d_time, d_nodes };
+    st |= nc_def_var(nc, "vals_nod_var1", NC_DOUBLE, 2, dd, &v_u); }
+  st |= nc_enddef(nc);
+  // Exodus node order intentionally differs from the QUAD4 connectivity order:
+  // nodes 1..4 are top-left, bottom-left, top-right, bottom-right.
+  double x[4] = { 0., 0., 1., 1. }, y[4] = { 1., 0., 1., 0. };
+  int conn[4] = { 2, 4, 3, 1 }, ebp[1] = { 1 };
+  double t[1] = { 0. }, vals[4] = { 10., 20., 30., 40. };
+  char name[33]; std::fill(name, name+33, '\0'); name[0] = 'u';
+  size_t ns[2] = { 0, 0 }, nc2[2] = { 1, 33 };
+  size_t us[2] = { 0, 0 }, uc[2] = { 1, 4 };
+  st |= nc_put_var_double(nc, v_x, x);
+  st |= nc_put_var_double(nc, v_y, y);
+  st |= nc_put_var_int(nc, v_conn, conn);
+  st |= nc_put_var_int(nc, v_ebp, ebp);
+  st |= nc_put_var_double(nc, v_time, t);
+  st |= nc_put_vara_text(nc, v_nvn, ns, nc2, name);
+  st |= nc_put_vara_double(nc, v_u, us, uc, vals);
+  st |= nc_close(nc);
+  check(st == NC_NOERR, tag + ": wrote fixture");
+
+  getfem::mesh m;
+  getfem::exodus_import imp(fname);
+  imp.read_mesh(m);
+  getfem::mesh_fem mf;
+  imp.build_mesh_fem(m, mf);
+  std::vector<scalar_type> U;
+  imp.read_nodal_var("u", 0, U);
+  check(U.size() == mf.nb_dof() && mf.nb_dof() == 4,
+        tag + ": nodal variable length matches reduced mesh_fem dofs");
+  std::vector<scalar_type> Ub(mf.nb_basic_dof());
+  mf.extend_vector(U, Ub);
+  size_type cv = m.convex_index().first_true();
+  getfem::mesh_fem::ind_dof_ct dofs = mf.ind_basic_dof_of_element(cv);
+  const bgeot::mesh_structure::ind_cv_ct &pts = m.ind_points_of_convex(cv);
+  bool order_ok = true;
+  for (size_type j=0; j < pts.size(); ++j)
+    if (gmm::abs(Ub[dofs[j]] - vals[pts[j]]) > 1e-12) order_ok = false;
+  check(order_ok, tag + ": reduced dofs follow Exodus node order");
+  cout << "  " << tag << ": reduced dofs match Exodus node order" << endl;
+}
+
+static void test_append_block_layout_mismatch() {
+  std::string tag = "append block layout mismatch";
+  const char *fname = "test_exodus_append_mismatch.exo";
+  getfem::mesh m;
+  getfem::regular_unit_mesh(m, {3,3}, bgeot::geometric_trans_descriptor("GT_QK(2,1)"));
+  getfem::mesh_fem mf(m); mf.set_classical_finite_element(1);
+  std::vector<scalar_type> U(mf.nb_dof());
+  for (size_type i=0; i < mf.nb_dof(); ++i) U[i] = field(mf.point_of_basic_dof(i));
+  { getfem::exodus_export ex(fname);
+    ex.enable_region_field(); ex.exporting(mf); ex.write_mesh();
+    ex.write_point_data(mf, U, "u"); ex.close(); }
+
+  size_type c = 0;
+  for (dal::bv_visitor cv(m.convex_index()); !cv.finished(); ++cv, ++c)
+    m.region(c % 2 ? 6 : 5).add(cv);
+  expect_gmm_error(tag, [&]() {
+    getfem::exodus_export ex(fname, true);
+    ex.exporting(mf);
+  }, "fingerprint");
+  cout << "  " << tag << ": refused append to changed element blocks" << endl;
+}
+
+static void test_incomplete_step_error_timing() {
+  std::string tag = "incomplete transient step";
+  const char *fname = "test_exodus_incomplete.exo";
+  getfem::mesh m;
+  getfem::regular_unit_mesh(m, {2,2}, bgeot::geometric_trans_descriptor("GT_QK(2,1)"));
+  getfem::mesh_fem mf(m); mf.set_classical_finite_element(1);
+  std::vector<scalar_type> U(mf.nb_dof()), V(mf.nb_dof());
+  for (size_type i=0; i < mf.nb_dof(); ++i) {
+    U[i] = field(mf.point_of_basic_dof(i));
+    V[i] = 2.*U[i];
+  }
+
+  { getfem::exodus_export ex(fname);
+    ex.exporting(mf); ex.declare_point_data("u"); ex.declare_point_data("v");
+    ex.write_mesh();
+    ex.set_time(0.); ex.write_point_data(mf, U, "u");
+    ex.write_point_data(mf, V, "v");
+    ex.set_time(1.); ex.write_point_data(mf, U, "u");
+    expect_gmm_error(tag + ": next set_time", [&]() { ex.set_time(2.); },
+                     "every field");
+  }
+
+  { getfem::exodus_export ex(fname);
+    ex.exporting(mf); ex.declare_point_data("u"); ex.declare_point_data("v");
+    ex.write_mesh();
+    ex.set_time(0.); ex.write_point_data(mf, U, "u");
+    expect_gmm_error(tag + ": close", [&]() { ex.close(); }, "every field");
+  }
+  cout << "  " << tag << ": rejected before syncing/closing incomplete steps" << endl;
+}
+
+static void test_shell_sideset_import() {
+  std::string tag = "shell side-set import";
+  const char *fname = "test_exodus_shell_sideset.exo";
+  int nc, st = 0;
+  st |= nc_create(fname, NC_CLOBBER | NC_64BIT_OFFSET, &nc);
+  int d_dim, d_nodes, d_blk, d_ne, d_npe, d_nss, d_nside;
+  st |= nc_def_dim(nc, "num_dim", 2, &d_dim);
+  st |= nc_def_dim(nc, "num_nodes", 4, &d_nodes);
+  st |= nc_def_dim(nc, "num_el_blk", 1, &d_blk);
+  st |= nc_def_dim(nc, "num_el_in_blk1", 1, &d_ne);
+  st |= nc_def_dim(nc, "num_nod_per_el1", 4, &d_npe);
+  st |= nc_def_dim(nc, "num_side_sets", 1, &d_nss);
+  st |= nc_def_dim(nc, "num_side_ss1", 1, &d_nside);
+  int v_x, v_y, v_conn, v_ebp, v_ssp, v_e, v_s;
+  st |= nc_def_var(nc, "coordx", NC_DOUBLE, 1, &d_nodes, &v_x);
+  st |= nc_def_var(nc, "coordy", NC_DOUBLE, 1, &d_nodes, &v_y);
+  { int dd[2] = { d_ne, d_npe };
+    st |= nc_def_var(nc, "connect1", NC_INT, 2, dd, &v_conn); }
+  st |= nc_put_att_text(nc, v_conn, "elem_type", 6, "SHELL4");
+  st |= nc_def_var(nc, "eb_prop1", NC_INT, 1, &d_blk, &v_ebp);
+  st |= nc_def_var(nc, "ss_prop1", NC_INT, 1, &d_nss, &v_ssp);
+  st |= nc_def_var(nc, "elem_ss1", NC_INT, 1, &d_nside, &v_e);
+  st |= nc_def_var(nc, "side_ss1", NC_INT, 1, &d_nside, &v_s);
+  st |= nc_enddef(nc);
+  double x[4] = {0.,1.,1.,0.}, y[4] = {0.,0.,1.,1.};
+  int conn[4] = {1,2,3,4}, one[1] = {1};
+  st |= nc_put_var_double(nc, v_x, x); st |= nc_put_var_double(nc, v_y, y);
+  st |= nc_put_var_int(nc, v_conn, conn);
+  st |= nc_put_var_int(nc, v_ebp, one); st |= nc_put_var_int(nc, v_ssp, one);
+  st |= nc_put_var_int(nc, v_e, one); st |= nc_put_var_int(nc, v_s, one);
+  st |= nc_close(nc);
+  check(st == NC_NOERR, tag + ": wrote shell fixture");
+
+  expect_gmm_error(tag, [&]() {
+    getfem::mesh m;
+    getfem::exodus_import imp(fname);
+    imp.read_mesh(m);
+  }, "SHELL");
+  cout << "  " << tag << ": unsupported shell side sets are rejected" << endl;
+}
+
+// serendipity (incomplete) elements QUAD8 / HEX20 / WEDGE15 round-trip
+static void test_serendipity_roundtrip(const std::string &gt, const char *fem,
+                                       const std::vector<size_type> &nsub) {
+  std::string tag = std::string(fem);
+  const char *fname = "test_exodus_ser.exo";
+  getfem::mesh m;
+  getfem::regular_unit_mesh(m, nsub, bgeot::geometric_trans_descriptor(gt));
+  getfem::mesh_fem mf(m);
+  for (dal::bv_visitor cv(m.convex_index()); !cv.finished(); ++cv)
+    mf.set_finite_element(cv, getfem::fem_descriptor(fem));
+  std::vector<scalar_type> U(mf.nb_dof());
+  for (size_type i=0; i < mf.nb_dof(); ++i) U[i] = field(mf.point_of_basic_dof(i));
+  { getfem::exodus_export ex(fname); ex.exporting(mf); ex.write_mesh();
+    ex.write_point_data(mf, U, "u"); }
+  getfem::mesh m2; getfem::exodus_import imp(fname); imp.read_mesh(m2);
+  check(m2.convex_index().card() == m.convex_index().card(), tag + ": element count");
+  std::vector<scalar_type> Ub; imp.read_nodal_var("u", 0, Ub);
+  scalar_type err = node_value_error(imp, Ub, 1.);
+  check(err < 1e-10, tag + ": field values (err=" + std::to_string(err) + ")");
+  cout << "  " << tag << ": " << m2.convex_index().card() << " elements, "
+       << Ub.size() << " nodes, value error " << err << endl;
+}
+
+// a vector (qdim>1) field is written as components name_x / name_y
+static void test_vector_field_roundtrip() {
+  const char *fname = "test_exodus_vec.exo";
+  getfem::mesh m;
+  getfem::regular_unit_mesh(m, {3,3}, bgeot::geometric_trans_descriptor("GT_QK(2,1)"));
+  getfem::mesh_fem mf(m); mf.set_qdim(2); mf.set_classical_finite_element(1);
+  std::vector<scalar_type> U(mf.nb_dof());
+  for (size_type i=0; i < mf.nb_dof(); ++i) U[i] = field(mf.point_of_basic_dof(i));
+  { getfem::exodus_export ex(fname); ex.exporting(mf); ex.write_mesh();
+    ex.write_point_data(mf, U, "disp"); }
+  getfem::mesh m2; getfem::exodus_import imp(fname); imp.read_mesh(m2);
+  std::vector<scalar_type> Ux, Uy;
+  imp.read_nodal_var("disp_x", 0, Ux);
+  imp.read_nodal_var("disp_y", 0, Uy);
+  scalar_type err = std::max(node_value_error(imp, Ux, 1.),
+                             node_value_error(imp, Uy, 1.));
+  check(err < 1e-10, "vector field: disp_x/_y values (err="
+        + std::to_string(err) + ")");
+  cout << "  vector field: disp_x/_y round-trip, value error " << err << endl;
+}
+
+// default files are compressed NetCDF4 classic-model when the NetCDF build
+// supports deflate; 'uncompressed' is always classic 64-bit offset
+static void test_compression_format() {
+  getfem::mesh m;
+  getfem::regular_unit_mesh(m, {3,3}, bgeot::geometric_trans_descriptor("GT_QK(2,1)"));
+  getfem::mesh_fem mf(m); mf.set_classical_finite_element(1);
+  std::vector<scalar_type> U(mf.nb_dof());
+  for (size_type i=0; i < mf.nb_dof(); ++i) U[i] = field(mf.point_of_basic_dof(i));
+  { getfem::exodus_export ex("test_exodus_c.exo");
+    ex.exporting(mf); ex.write_mesh(); ex.write_point_data(mf, U, "u"); }
+  { getfem::exodus_export ex("test_exodus_u.exo");
+    ex.enable_compression(0); ex.exporting(mf); ex.write_mesh();
+    ex.write_point_data(mf, U, "u"); }
+  int nc = -1, fmt = 0;
+  if (nc_open("test_exodus_c.exo", NC_NOWRITE, &nc) == NC_NOERR) {
+    nc_inq_format(nc, &fmt); nc_close(nc);
+#ifdef GETFEM_HAVE_EXODUS_NETCDF4
+    check(fmt == NC_FORMAT_NETCDF4_CLASSIC,
+          "compression: default file is NetCDF4 classic-model");
+#else
+    check(fmt == NC_FORMAT_64BIT_OFFSET,
+          "compression: default file is 64-bit offset without NetCDF4 deflate");
+#endif
+  }
+  if (nc_open("test_exodus_u.exo", NC_NOWRITE, &nc) == NC_NOERR) {
+    nc_inq_format(nc, &fmt); nc_close(nc);
+    check(fmt == NC_FORMAT_64BIT_OFFSET,
+          "compression: 'uncompressed' file is 64-bit offset");
+  }
+  getfem::mesh mc;
+  { getfem::exodus_import imp("test_exodus_c.exo"); imp.read_mesh(mc); }
+  check(mc.convex_index().card() == m.convex_index().card(),
+        "compression: default file re-imports");
+#ifndef GETFEM_HAVE_EXODUS_NETCDF4
+  expect_gmm_error("compression unavailable", [&]() {
+    getfem::exodus_export ex("test_exodus_need_netcdf4.exo");
+    ex.enable_compression();
+  }, "NetCDF4");
+#endif
+#ifdef GETFEM_HAVE_EXODUS_NETCDF4
+  cout << "  compression: default NetCDF4-classic, 'uncompressed' 64-bit offset"
+       << endl;
+#else
+  cout << "  compression: default and 'uncompressed' both use 64-bit offset "
+       << "without NetCDF4 deflate" << endl;
+#endif
+}
+
+// malformed import files must be rejected with a clean error, not crash/UB
+static void test_import_rejections() {
+  auto write_fixture = [](const char *fname, size_t num_dim, int last_conn) {
+    int nc, st = 0;
+    st |= nc_create(fname, NC_CLOBBER | NC_64BIT_OFFSET, &nc);
+    int d_dim, d_nodes, d_blk, d_ne, d_npe;
+    st |= nc_def_dim(nc, "num_dim", num_dim, &d_dim);
+    st |= nc_def_dim(nc, "num_nodes", 4, &d_nodes);
+    st |= nc_def_dim(nc, "num_el_blk", 1, &d_blk);
+    st |= nc_def_dim(nc, "num_el_in_blk1", 1, &d_ne);
+    st |= nc_def_dim(nc, "num_nod_per_el1", 4, &d_npe);
+    int v_coord, v_conn;
+    { int dd[2] = { d_dim, d_nodes };
+      st |= nc_def_var(nc, "coord", NC_DOUBLE, 2, dd, &v_coord); }
+    { int dd[2] = { d_ne, d_npe };
+      st |= nc_def_var(nc, "connect1", NC_INT, 2, dd, &v_conn); }
+    st |= nc_put_att_text(nc, v_conn, "elem_type", 5, "QUAD4");
+    st |= nc_enddef(nc);
+    std::vector<double> coord(num_dim*4, 0.);
+    st |= nc_put_var_double(nc, v_coord, coord.data());
+    int conn[4] = { 1, 2, 3, last_conn };
+    st |= nc_put_var_int(nc, v_conn, conn);
+    st |= nc_close(nc);
+    return st == NC_NOERR;
+  };
+  write_fixture("test_exodus_badconn.exo", 2, 99);     // node id out of range
+  expect_gmm_error("import rejection (connectivity)", [&]() {
+    getfem::mesh m; getfem::exodus_import imp("test_exodus_badconn.exo");
+    imp.read_mesh(m);
+  }, "out of range");
+  write_fixture("test_exodus_baddim.exo", 4, 4);       // unsupported num_dim
+  expect_gmm_error("import rejection (num_dim)", [&]() {
+    getfem::mesh m; getfem::exodus_import imp("test_exodus_baddim.exo");
+    imp.read_mesh(m);
+  }, "dimension");
+
+  auto write_set_fixture = [](const char *fname, const std::string &kind) {
+    int nc, st = 0;
+    st |= nc_create(fname, NC_CLOBBER | NC_64BIT_OFFSET, &nc);
+    int d_dim, d_nodes, d_blk, d_ne, d_npe;
+    st |= nc_def_dim(nc, "num_dim", 2, &d_dim);
+    st |= nc_def_dim(nc, "num_nodes", 4, &d_nodes);
+    st |= nc_def_dim(nc, "num_el_blk", 1, &d_blk);
+    st |= nc_def_dim(nc, "num_el_in_blk1", 1, &d_ne);
+    st |= nc_def_dim(nc, "num_nod_per_el1", 4, &d_npe);
+    int v_x, v_y, v_conn;
+    st |= nc_def_var(nc, "coordx", NC_DOUBLE, 1, &d_nodes, &v_x);
+    st |= nc_def_var(nc, "coordy", NC_DOUBLE, 1, &d_nodes, &v_y);
+    { int dd[2] = { d_ne, d_npe };
+      st |= nc_def_var(nc, "connect1", NC_INT, 2, dd, &v_conn); }
+    st |= nc_put_att_text(nc, v_conn, "elem_type", 5, "QUAD4");
+    int v_bad_a = -1, v_bad_b = -1, d_set = -1, d_entries = -1;
+    if (kind == "side_elem" || kind == "side_side") {
+      st |= nc_def_dim(nc, "num_side_sets", 1, &d_set);
+      st |= nc_def_dim(nc, "num_side_ss1", 1, &d_entries);
+      st |= nc_def_var(nc, "elem_ss1", NC_INT, 1, &d_entries, &v_bad_a);
+      st |= nc_def_var(nc, "side_ss1", NC_INT, 1, &d_entries, &v_bad_b);
+    } else if (kind == "element") {
+      st |= nc_def_dim(nc, "num_elem_sets", 1, &d_set);
+      st |= nc_def_dim(nc, "num_ele_els1", 1, &d_entries);
+      st |= nc_def_var(nc, "elem_els1", NC_INT, 1, &d_entries, &v_bad_a);
+    } else if (kind == "node") {
+      st |= nc_def_dim(nc, "num_node_sets", 1, &d_set);
+      st |= nc_def_dim(nc, "num_nod_ns1", 1, &d_entries);
+      st |= nc_def_var(nc, "node_ns1", NC_INT, 1, &d_entries, &v_bad_a);
+    } else return false;
+    st |= nc_enddef(nc);
+    double x[4] = { 0., 1., 1., 0. };
+    double y[4] = { 0., 0., 1., 1. };
+    int conn[4] = { 1, 2, 3, 4 };
+    st |= nc_put_var_double(nc, v_x, x);
+    st |= nc_put_var_double(nc, v_y, y);
+    st |= nc_put_var_int(nc, v_conn, conn);
+    if (kind == "side_elem") {
+      int elem = 99, side = 1;
+      st |= nc_put_var_int(nc, v_bad_a, &elem);
+      st |= nc_put_var_int(nc, v_bad_b, &side);
+    } else if (kind == "side_side") {
+      int elem = 1, side = 99;
+      st |= nc_put_var_int(nc, v_bad_a, &elem);
+      st |= nc_put_var_int(nc, v_bad_b, &side);
+    } else if (kind == "element") {
+      int elem = 99;
+      st |= nc_put_var_int(nc, v_bad_a, &elem);
+    } else {
+      int node = 99;
+      st |= nc_put_var_int(nc, v_bad_a, &node);
+    }
+    st |= nc_close(nc);
+    return st == NC_NOERR;
+  };
+  check(write_set_fixture("test_exodus_bad_side_elem.exo", "side_elem"),
+        "import rejection fixture: side-set element id");
+  expect_gmm_error("import rejection (side-set element id)", [&]() {
+    getfem::mesh m; getfem::exodus_import imp("test_exodus_bad_side_elem.exo");
+    imp.read_mesh(m);
+  }, "side set");
+  check(write_set_fixture("test_exodus_bad_side_side.exo", "side_side"),
+        "import rejection fixture: side-set side id");
+  expect_gmm_error("import rejection (side-set side id)", [&]() {
+    getfem::mesh m; getfem::exodus_import imp("test_exodus_bad_side_side.exo");
+    imp.read_mesh(m);
+  }, "side set");
+  check(write_set_fixture("test_exodus_bad_elemset.exo", "element"),
+        "import rejection fixture: element-set element id");
+  expect_gmm_error("import rejection (element-set element id)", [&]() {
+    getfem::mesh m; getfem::exodus_import imp("test_exodus_bad_elemset.exo");
+    imp.read_mesh(m);
+  }, "element set");
+  check(write_set_fixture("test_exodus_bad_nodeset.exo", "node"),
+        "import rejection fixture: node-set node id");
+  expect_gmm_error("import rejection (node-set node id)", [&]() {
+    getfem::mesh m; getfem::exodus_import imp("test_exodus_bad_nodeset.exo");
+    imp.read_mesh(m);
+  }, "node set");
+  cout << "  import rejection: bad dimensions, connectivity and set ids are "
+       << "rejected" << endl;
+}
+
+int main() {
+  cout << "Exodus round-trip tests" << endl;
+  test_roundtrip("GT_PK(1,1)",  1, {4});       // BAR2
+  test_roundtrip("GT_PK(1,1)",  2, {4});       // BAR3
+  test_roundtrip("GT_PK(2,1)",  1, {3,3});     // TRI3
+  test_roundtrip("GT_PK(2,1)",  2, {3,3});     // TRI6
+  test_roundtrip("GT_QK(2,1)",  1, {3,3});     // QUAD4
+  test_roundtrip("GT_QK(2,1)",  2, {3,3});     // QUAD9
+  test_roundtrip("GT_PK(3,1)",  1, {2,2,2});   // TETRA4
+  test_roundtrip("GT_PK(3,1)",  2, {2,2,2});   // TETRA10
+  test_roundtrip("GT_QK(3,1)",  1, {2,2,2});   // HEX8
+  test_roundtrip("GT_QK(3,1)",  2, {2,2,2});   // HEX27
+  test_roundtrip("GT_PRISM(3,1)", 1, {2,2,2}); // WEDGE6
+  test_region_roundtrip("GT_PK(2,1)", {3,3});
+  test_region_roundtrip("GT_QK(2,1)", {3,3});
+  test_region_roundtrip("GT_PK(3,1)", {2,2,2});
+  test_region_roundtrip("GT_QK(3,1)", {2,2,2});
+  test_volume_region_roundtrip("GT_PK(2,1)", {3,3});
+  test_volume_region_roundtrip("GT_QK(3,1)", {2,2,2});
+  test_cell_var_and_names("GT_QK(2,1)", {3,3});
+  test_cell_var_and_names("GT_PK(3,1)", {2,2,2});
+  test_packed_coord_import();
+  test_import_build_mesh_fem_node_order();
+  test_append_block_layout_mismatch();
+  test_incomplete_step_error_timing();
+  test_shell_sideset_import();
+  test_serendipity_roundtrip("GT_QK(2,1)", "FEM_Q2_INCOMPLETE(2)", {2,2});       // QUAD8
+  test_serendipity_roundtrip("GT_QK(3,1)", "FEM_Q2_INCOMPLETE(3)", {2,2,2});     // HEX20
+  test_serendipity_roundtrip("GT_PRISM(3,1)", "FEM_PRISM_INCOMPLETE_P2", {2,2,2}); // WEDGE15
+  test_vector_field_roundtrip();
+  test_compression_format();
+  test_import_rejections();
+  test_time_series();
+  cout << (nb_errors ? "FAILED" : "all Exodus round-trip tests passed") << endl;
+  return nb_errors ? 1 : 0;
+}
+
+#else
+int main() { cout << "GetFEM built without Exodus support, test skipped\n"; return 0; }
+#endif

--- a/tests/test_exodus.pl
+++ b/tests/test_exodus.pl
@@ -1,0 +1,29 @@
+# Copyright (C) 2026 GetFEM contributors
+#
+# This file is a part of GetFEM
+#
+# GetFEM  is  free software;  you  can  redistribute  it  and/or modify it
+# under  the  terms  of the  GNU  Lesser General Public License as published
+# by  the  Free Software Foundation;  either version 3 of the License,  or
+# (at your option) any later version along with the GCC Runtime Library
+# Exception either version 3.1 or (at your option) any later version.
+# This program  is  distributed  in  the  hope  that it will be useful,  but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or  FITNESS  FOR  A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+# License and GCC Runtime Library Exception for more details.
+# You  should  have received a copy of the GNU Lesser General Public License
+# along  with  this program.  If not, see https://www.gnu.org/licenses/.
+
+$er = 0;
+open F, "./test_exodus 2>&1 |" or die;
+while (<F>) {
+  # print $_;
+  if ($_ =~ /error has been detected/)
+  {
+    $er = 1;
+    print " =============================================================\n";
+    print $_, <F>;
+  }
+}
+close(F); if ($?) { exit(1); }
+if ($er == 1) { exit(1); }


### PR DESCRIPTION
## Summary

Adds optional **Exodus II** finite-element database read/write to GetFEM, implemented
directly on the NetCDF C API (no SEACAS dependency). It lets GetFEM exchange meshes,
regions and (transient) nodal results with tools such as ParaView, Cubit and the
SEACAS ecosystem.

The feature is **off by default** and fully optional: configure with `--enable-exodus`
(autotools) or `-DENABLE_EXODUS=ON` (CMake). When disabled, NetCDF is never probed and
none of the code is compiled in; the scripting commands return a clear
"rebuild with --enable-exodus" error.

## What it adds

- **C++ API** (`getfem/getfem_exodus.h`): `getfem::exodus_export` / `exodus_import`,
  plus an `import_mesh(..., "exodus", ...)` hook.
- **Scripting API** (Python / MATLAB / Octave / Scilab): `MeshFem:export_to_exodus`,
  `Mesh:export_to_exodus`, `Mesh:exodus_nodal_data`.
- **Element types**: all linear and quadratic types, including serendipity
  QUAD8 / HEX20 / WEDGE15. The GetFEM↔Exodus node ordering is derived by
  reference-coordinate matching (no hand tables); HEX27 cross-checked against libMesh.
- **Regions** → side sets / element sets / node sets; each volume region also becomes a
  named element block, with an optional per-cell `region` variable and user region names.
- **Transient series** in a single file, streamed/appended incrementally, with a
  mesh-fingerprint guard on append.
- **Compression**: compressed NetCDF4 (classic model) by default when the NetCDF library
  provides HDF5 deflate, with a runtime fallback to classic 64-bit-offset; `'uncompressed'`
  (or `enable_compression(0)`) opts out.
- **Hardened import**: bounds-checked connectivity, set ids and spatial dimension, so a
  malformed/foreign file errors cleanly rather than crashing.

## Testing

- C++ round-trip tests (`tests/test_exodus.cc`) and Python tests
  (`interface/tests/python/check_exodus.py`): geometry, scalar and vector fields,
  regions/sets/names, serendipity elements, transient append, compression, and
  malformed-file rejection.
- A macOS GitHub Actions workflow builds and tests both the **enabled** and **disabled**
  configurations.
- User documentation in `doc/sphinx/source/userdoc/export.rst`.

## Note for reviewers: default output format

New files are written as **compressed NetCDF4 (classic model)** by default. This is valid
Exodus II, read transparently by modern (HDF5-enabled) readers such as ParaView, and it
greatly reduces large/transient file sizes. It does require an HDF5-capable reader, and for
very small meshes the HDF5 container overhead can make a compressed file no smaller than a
classic one. `'uncompressed'` / `enable_compression(0)` writes a classic 64-bit-offset file
for the broadest compatibility. Happy to flip the default to uncompressed-with-opt-in if
the maintainers prefer the more conservative choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
